### PR TITLE
Cast to `unsigned char` before calling `toupper()`

### DIFF
--- a/inst/include/date/date.h
+++ b/inst/include/date/date.h
@@ -4797,7 +4797,10 @@ scan_keyword(std::basic_istream<CharT, Traits>& is, FwdIter kb, FwdIter ke)
             is.setstate(std::ios::eofbit);
             break;
         }
-        auto c = static_cast<char>(toupper(ic));
+        // clock-edit-start
+        // Note: Casting to unsigned char first is recommended by `toupper()`
+        auto c = static_cast<char>(toupper(static_cast<unsigned char>(ic)));
+        // clock-edit-stop
         bool consume = false;
         // For each keyword which might match, see if the indx character is c
         // If a match if found, consume c
@@ -4810,7 +4813,9 @@ scan_keyword(std::basic_istream<CharT, Traits>& is, FwdIter kb, FwdIter ke)
         {
             if (*st == might_match)
             {
-                if (c == static_cast<char>(toupper((*ky)[indx])))
+                // clock-edit-start
+                if (c == static_cast<char>(toupper(static_cast<unsigned char>((*ky)[indx]))))
+                // clock-edit-stop
                 {
                     consume = true;
                     if (ky->size() == indx+1)

--- a/tests/testthat/test-gregorian-year-month-day.R
+++ b/tests/testthat/test-gregorian-year-month-day.R
@@ -237,6 +237,20 @@ test_that("can use a different locale", {
   )
 })
 
+test_that("can use a different locale with UTF-8 strings", {
+  x <- c("1月 01 2019", "3月 05 2020")
+  y <- "ለካቲት 01 2019"
+
+  expect_identical(
+    year_month_day_parse(x, format = "%B %d %Y", locale = clock_locale("ja")),
+    year_month_day(c(2019, 2020), c(1, 3), c(1, 5))
+  )
+  expect_identical(
+    year_month_day_parse(y, format = "%B %d %Y", locale = clock_locale("ti")),
+    year_month_day(2019, 2, 1)
+  )
+})
+
 test_that("parsing NA returns NA", {
   expect_identical(
     year_month_day_parse(NA_character_),


### PR DESCRIPTION
Note that this is a change to date.h directly

The standard recommends passing unsigned char to `toupper()`, as passing a char that might be negative would result in undefined behavior. This is exactly what was happening to us when using a non-English locale.

Notes section of https://en.cppreference.com/w/cpp/string/byte/toupper
https://stackoverflow.com/questions/21805674/do-i-need-to-cast-to-unsigned-char-before-calling-toupper-tolower-et-al