### PR TITLE
Ensure input, labels, and format are all in UTF-8 when parsing

### DIFF
--- a/src/gregorian-year-month-day.cpp
+++ b/src/gregorian-year-month-day.cpp
@@ -823,7 +823,7 @@ template <class Calendar>
 inline
 void
 year_month_day_from_stream(std::istringstream& stream,
-                           const std::vector<const char*>& fmts,
+                           const std::vector<std::string>& fmts,
                            const std::pair<const std::string*, const std::string*>& month_names_pair,
                            const std::pair<const std::string*, const std::string*>& weekday_names_pair,
                            const std::pair<const std::string*, const std::string*>& ampm_names_pair,
@@ -838,7 +838,7 @@ year_month_day_from_stream(std::istringstream& stream,
     stream.clear();
     stream.seekg(0);
 
-    const char* fmt = fmts[j];
+    const char* fmt = fmts[j].c_str();
     date::year_month_day ymd{};
     date::hh_mm_ss<Duration> hms{};
 
@@ -871,7 +871,7 @@ template <>
 inline
 void
 year_month_day_from_stream(std::istringstream& stream,
-                           const std::vector<const char*>& fmts,
+                           const std::vector<std::string>& fmts,
                            const std::pair<const std::string*, const std::string*>& month_names_pair,
                            const std::pair<const std::string*, const std::string*>& weekday_names_pair,
                            const std::pair<const std::string*, const std::string*>& ampm_names_pair,
@@ -885,7 +885,7 @@ year_month_day_from_stream(std::istringstream& stream,
     stream.clear();
     stream.seekg(0);
 
-    const char* fmt = fmts[j];
+    const char* fmt = fmts[j].c_str();
     date::year x{};
 
     rclock::from_stream(
@@ -912,7 +912,7 @@ template <>
 inline
 void
 year_month_day_from_stream(std::istringstream& stream,
-                           const std::vector<const char*>& fmts,
+                           const std::vector<std::string>& fmts,
                            const std::pair<const std::string*, const std::string*>& month_names_pair,
                            const std::pair<const std::string*, const std::string*>& weekday_names_pair,
                            const std::pair<const std::string*, const std::string*>& ampm_names_pair,
@@ -926,7 +926,7 @@ year_month_day_from_stream(std::istringstream& stream,
     stream.clear();
     stream.seekg(0);
 
-    const char* fmt = fmts[j];
+    const char* fmt = fmts[j].c_str();
     date::year_month x{};
 
     rclock::from_stream(
@@ -953,7 +953,7 @@ template <>
 inline
 void
 year_month_day_from_stream(std::istringstream& stream,
-                           const std::vector<const char*>& fmts,
+                           const std::vector<std::string>& fmts,
                            const std::pair<const std::string*, const std::string*>& month_names_pair,
                            const std::pair<const std::string*, const std::string*>& weekday_names_pair,
                            const std::pair<const std::string*, const std::string*>& ampm_names_pair,
@@ -967,7 +967,7 @@ year_month_day_from_stream(std::istringstream& stream,
     stream.clear();
     stream.seekg(0);
 
-    const char* fmt = fmts[j];
+    const char* fmt = fmts[j].c_str();
     date::year_month_day x{};
 
     rclock::from_stream(
@@ -994,7 +994,7 @@ template <>
 inline
 void
 year_month_day_from_stream(std::istringstream& stream,
-                           const std::vector<const char*>& fmts,
+                           const std::vector<std::string>& fmts,
                            const std::pair<const std::string*, const std::string*>& month_names_pair,
                            const std::pair<const std::string*, const std::string*>& weekday_names_pair,
                            const std::pair<const std::string*, const std::string*>& ampm_names_pair,
@@ -1008,7 +1008,7 @@ year_month_day_from_stream(std::istringstream& stream,
     stream.clear();
     stream.seekg(0);
 
-    const char* fmt = fmts[j];
+    const char* fmt = fmts[j].c_str();
     date::year_month_day ymd{};
     date::hh_mm_ss<std::chrono::seconds> hms{};
 
@@ -1038,7 +1038,7 @@ template <>
 inline
 void
 year_month_day_from_stream(std::istringstream& stream,
-                           const std::vector<const char*>& fmts,
+                           const std::vector<std::string>& fmts,
                            const std::pair<const std::string*, const std::string*>& month_names_pair,
                            const std::pair<const std::string*, const std::string*>& weekday_names_pair,
                            const std::pair<const std::string*, const std::string*>& ampm_names_pair,
@@ -1052,7 +1052,7 @@ year_month_day_from_stream(std::istringstream& stream,
     stream.clear();
     stream.seekg(0);
 
-    const char* fmt = fmts[j];
+    const char* fmt = fmts[j].c_str();
     date::year_month_day ymd{};
     date::hh_mm_ss<std::chrono::seconds> hms{};
 
@@ -1083,7 +1083,7 @@ template <>
 inline
 void
 year_month_day_from_stream(std::istringstream& stream,
-                           const std::vector<const char*>& fmts,
+                           const std::vector<std::string>& fmts,
                            const std::pair<const std::string*, const std::string*>& month_names_pair,
                            const std::pair<const std::string*, const std::string*>& weekday_names_pair,
                            const std::pair<const std::string*, const std::string*>& ampm_names_pair,
@@ -1097,7 +1097,7 @@ year_month_day_from_stream(std::istringstream& stream,
     stream.clear();
     stream.seekg(0);
 
-    const char* fmt = fmts[j];
+    const char* fmt = fmts[j].c_str();
     date::year_month_day ymd{};
     date::hh_mm_ss<std::chrono::seconds> hms{};
 
@@ -1139,7 +1139,7 @@ year_month_day_parse_impl(const cpp11::strings& x,
   const r_ssize size = x.size();
   Calendar out(size);
 
-  std::vector<const char*> fmts(format.size());
+  std::vector<std::string> fmts(format.size());
   rclock::fill_formats(format, fmts);
 
   char dmark;

--- a/src/gregorian-year-month-day.cpp
+++ b/src/gregorian-year-month-day.cpp
@@ -1173,6 +1173,8 @@ year_month_day_parse_impl(const cpp11::strings& x,
 
   std::istringstream stream;
 
+  void* vmax = vmaxget();
+
   for (r_ssize i = 0; i < size; ++i) {
     const SEXP elt = x[i];
 
@@ -1181,7 +1183,9 @@ year_month_day_parse_impl(const cpp11::strings& x,
       continue;
     }
 
-    stream.str(CHAR(elt));
+    const char* p_elt = Rf_translateCharUTF8(elt);
+
+    stream.str(p_elt);
 
     year_month_day_from_stream(
       stream,
@@ -1195,6 +1199,8 @@ year_month_day_parse_impl(const cpp11::strings& x,
       out
     );
   }
+
+  vmaxset(vmax);
 
   if (failures.any_failures()) {
     failures.warn();

--- a/src/locale.h
+++ b/src/locale.h
@@ -14,11 +14,12 @@ fill_weekday_names(const cpp11::strings& weekday,
                    const cpp11::strings& weekday_abbrev,
                    std::string (&weekday_names)[14]) {
   for (int i = 0; i < 7; ++i) {
-    std::string string = weekday[i];
-    weekday_names[i] = string;
+    SEXP string = weekday[i];
+    weekday_names[i] = std::string{CHAR(string)};
   }
   for (int i = 0; i < 7; ++i) {
-    weekday_names[i + 7] = weekday_abbrev[i];
+    SEXP string = weekday_abbrev[i];
+    weekday_names[i + 7] = std::string{CHAR(string)};
   }
   return std::make_pair(weekday_names, weekday_names+sizeof(weekday_names)/sizeof(weekday_names[0]));
 }
@@ -30,11 +31,12 @@ fill_month_names(const cpp11::strings& month,
                  const cpp11::strings& month_abbrev,
                  std::string (&month_names)[24]) {
   for (int i = 0; i < 12; ++i) {
-    std::string string = month[i];
-    month_names[i] = string;
+    SEXP string = month[i];
+    month_names[i] = std::string{CHAR(string)};
   }
   for (int i = 0; i < 12; ++i) {
-    month_names[i + 12] = month_abbrev[i];
+    SEXP string = month_abbrev[i];
+    month_names[i + 12] = std::string{CHAR(string)};
   }
   return std::make_pair(month_names, month_names+sizeof(month_names)/sizeof(month_names[0]));
 }
@@ -44,8 +46,8 @@ inline
 std::pair<const std::string*, const std::string*>
 fill_ampm_names(const cpp11::strings& am_pm, std::string (&ampm_names)[2]) {
   for (int i = 0; i < 2; ++i) {
-    std::string string = am_pm[i];
-    ampm_names[i] = string;
+    SEXP string = am_pm[i];
+    ampm_names[i] = std::string{CHAR(string)};
   }
   return std::make_pair(ampm_names, ampm_names+sizeof(ampm_names)/sizeof(ampm_names[0]));
 }

--- a/src/parse.h
+++ b/src/parse.h
@@ -1418,10 +1418,11 @@ from_stream(std::basic_istream<CharT, Traits>& is,
 static
 inline
 void
-fill_formats(const cpp11::strings& src, std::vector<const char*>& dest) {
+fill_formats(const cpp11::strings& src, std::vector<std::string>& dest) {
     const r_ssize size = src.size();
     for (r_ssize i = 0; i < size; ++i) {
-        dest[i] = CHAR(src[i]);
+        std::string elt = src[i];
+        dest[i] = elt;
     }
 }
 

--- a/src/time-point.cpp
+++ b/src/time-point.cpp
@@ -101,7 +101,7 @@ static
 inline
 void
 time_point_parse_one(std::istringstream& stream,
-                     const std::vector<const char*>& fmts,
+                     const std::vector<std::string>& fmts,
                      const std::pair<const std::string*, const std::string*>& month_names_pair,
                      const std::pair<const std::string*, const std::string*>& weekday_names_pair,
                      const std::pair<const std::string*, const std::string*>& ampm_names_pair,
@@ -116,7 +116,7 @@ time_point_parse_one(std::istringstream& stream,
     stream.clear();
     stream.seekg(0);
 
-    const char* fmt = fmts[j];
+    const char* fmt = fmts[j].c_str();
     std::chrono::time_point<Clock, Duration> tp;
 
     rclock::from_stream(
@@ -153,7 +153,7 @@ time_point_parse_impl(const cpp11::strings& x,
   const r_ssize size = x.size();
   ClockDuration out(size);
 
-  std::vector<const char*> fmts(format.size());
+  std::vector<std::string> fmts(format.size());
   rclock::fill_formats(format, fmts);
 
   char dmark;

--- a/src/time-point.cpp
+++ b/src/time-point.cpp
@@ -187,6 +187,8 @@ time_point_parse_impl(const cpp11::strings& x,
 
   std::istringstream stream;
 
+  void* vmax = vmaxget();
+
   for (r_ssize i = 0; i < size; ++i) {
     const SEXP elt = x[i];
 
@@ -195,7 +197,9 @@ time_point_parse_impl(const cpp11::strings& x,
       continue;
     }
 
-    stream.str(CHAR(elt));
+    const char* p_elt = Rf_translateCharUTF8(elt);
+
+    stream.str(p_elt);
 
     time_point_parse_one<ClockDuration, Clock>(
       stream,
@@ -209,6 +213,8 @@ time_point_parse_impl(const cpp11::strings& x,
       out
     );
   }
+
+  vmaxset(vmax);
 
   if (failures.any_failures()) {
     failures.warn();

--- a/src/zoned-time.cpp
+++ b/src/zoned-time.cpp
@@ -429,7 +429,7 @@ static
 inline
 void
 zoned_parse_complete_one(std::istringstream& stream,
-                         const std::vector<const char*>& fmts,
+                         const std::vector<std::string>& fmts,
                          const std::pair<const std::string*, const std::string*>& month_names_pair,
                          const std::pair<const std::string*, const std::string*>& weekday_names_pair,
                          const std::pair<const std::string*, const std::string*>& ampm_names_pair,
@@ -448,7 +448,7 @@ zoned_parse_complete_one(std::istringstream& stream,
     stream.clear();
     stream.seekg(0);
 
-    const char* fmt = fmts[j];
+    const char* fmt = fmts[j].c_str();
 
     date::local_time<Duration> lt;
     std::string new_zone;
@@ -526,7 +526,7 @@ zoned_parse_complete_impl(const cpp11::strings& x,
   const r_ssize size = x.size();
   ClockDuration fields(size);
 
-  std::vector<const char*> fmts(format.size());
+  std::vector<std::string> fmts(format.size());
   rclock::fill_formats(format, fmts);
 
   char dmark;
@@ -639,7 +639,7 @@ static
 inline
 void
 zoned_parse_abbrev_one(std::istringstream& stream,
-                       const std::vector<const char*>& fmts,
+                       const std::vector<std::string>& fmts,
                        const std::pair<const std::string*, const std::string*>& month_names_pair,
                        const std::pair<const std::string*, const std::string*>& weekday_names_pair,
                        const std::pair<const std::string*, const std::string*>& ampm_names_pair,
@@ -656,7 +656,7 @@ zoned_parse_abbrev_one(std::istringstream& stream,
     stream.clear();
     stream.seekg(0);
 
-    const char* fmt = fmts[j];
+    const char* fmt = fmts[j].c_str();
 
     date::local_time<Duration> lt;
     std::string parsed_abbrev;
@@ -737,7 +737,7 @@ zoned_parse_abbrev_impl(const cpp11::strings& x,
   const r_ssize size = x.size();
   ClockDuration fields(size);
 
-  std::vector<const char*> fmts(format.size());
+  std::vector<std::string> fmts(format.size());
   rclock::fill_formats(format, fmts);
 
   char dmark;

--- a/src/zoned-time.cpp
+++ b/src/zoned-time.cpp
@@ -563,6 +563,8 @@ zoned_parse_complete_impl(const cpp11::strings& x,
 
   std::istringstream stream;
 
+  void* vmax = vmaxget();
+
   for (r_ssize i = 0; i < size; ++i) {
     const SEXP elt = x[i];
 
@@ -571,7 +573,9 @@ zoned_parse_complete_impl(const cpp11::strings& x,
       continue;
     }
 
-    stream.str(CHAR(elt));
+    const char* p_elt = Rf_translateCharUTF8(elt);
+
+    stream.str(p_elt);
 
     zoned_parse_complete_one(
       stream,
@@ -587,6 +591,8 @@ zoned_parse_complete_impl(const cpp11::strings& x,
       fields
     );
   }
+
+  vmaxset(vmax);
 
   if (failures.any_failures()) {
     failures.warn();
@@ -771,6 +777,8 @@ zoned_parse_abbrev_impl(const cpp11::strings& x,
 
   std::istringstream stream;
 
+  void* vmax = vmaxget();
+
   for (r_ssize i = 0; i < size; ++i) {
     const SEXP elt = x[i];
 
@@ -779,7 +787,9 @@ zoned_parse_abbrev_impl(const cpp11::strings& x,
       continue;
     }
 
-    stream.str(CHAR(elt));
+    const char* p_elt = Rf_translateCharUTF8(elt);
+
+    stream.str(p_elt);
 
     zoned_parse_abbrev_one(
       stream,
@@ -794,6 +804,8 @@ zoned_parse_abbrev_impl(const cpp11::strings& x,
       fields
     );
   }
+
+  vmaxset(vmax);
 
   if (failures.any_failures()) {
     failures.warn();

--- a/tests/testthat/test-clock-labels.R
+++ b/tests/testthat/test-clock-labels.R
@@ -31,7 +31,7 @@ test_that("input is validated", {
 
 test_that("custom labels are converted to UTF-8 upon entry", {
   labels <- clock_labels_lookup("fr")
-  month <- iconv(labels$month, "UTF-8", "latin1")
+  month <- iconv(labels$month, from = "UTF-8", to = "latin1")
 
   labels <- clock_labels(month, month, labels$weekday, labels$weekday, labels$am_pm)
 

--- a/tests/testthat/test-clock-labels.R
+++ b/tests/testthat/test-clock-labels.R
@@ -29,6 +29,20 @@ test_that("input is validated", {
   expect_snapshot_error(clock_labels(months, months, weekdays, weekdays, "x"))
 })
 
+test_that("custom labels are converted to UTF-8 upon entry", {
+  labels <- clock_labels_lookup("fr")
+  month <- iconv(labels$month, "UTF-8", "latin1")
+
+  labels <- clock_labels(month, month, labels$weekday, labels$weekday, labels$am_pm)
+
+  # French February can be marked as latin1
+  before <- month[2]
+  after <- labels$month[2]
+
+  expect_identical(Encoding(before), "latin1")
+  expect_identical(Encoding(after), "UTF-8")
+})
+
 # ------------------------------------------------------------------------------
 # clock_labels_lookup()
 

--- a/tests/testthat/test-gregorian-year-month-day.R
+++ b/tests/testthat/test-gregorian-year-month-day.R
@@ -252,10 +252,10 @@ test_that("can use a different locale with UTF-8 strings", {
 })
 
 test_that("`format` argument is translated to UTF-8", {
-  x <- enc2utf8("fév 2019-05-19")
+  x <- "f\u00E9v 2019-05-19"
 
-  format <- "fév %Y-%m-%d"
-  format <- iconv(format, to = "latin1")
+  format <- "f\u00E9v %Y-%m-%d"
+  format <- iconv(format, from = "UTF-8", to = "latin1")
 
   expect_identical(Encoding(x), "UTF-8")
   expect_identical(Encoding(format), "latin1")
@@ -267,8 +267,8 @@ test_that("`format` argument is translated to UTF-8", {
 })
 
 test_that("`x` is translated to UTF-8", {
-  x <- "2019-février-01"
-  x <- iconv(x, to = "latin1")
+  x <- "2019-f\u00E9vrier-01"
+  x <- iconv(x, from = "UTF-8", to = "latin1")
 
   locale <- clock_locale("fr")
   format <- "%Y-%B-%d"

--- a/tests/testthat/test-gregorian-year-month-day.R
+++ b/tests/testthat/test-gregorian-year-month-day.R
@@ -266,6 +266,22 @@ test_that("`format` argument is translated to UTF-8", {
   )
 })
 
+test_that("`x` is translated to UTF-8", {
+  x <- "2019-février-01"
+  x <- iconv(x, to = "latin1")
+
+  locale <- clock_locale("fr")
+  format <- "%Y-%B-%d"
+
+  expect_identical(Encoding(x), "latin1")
+  expect_identical(Encoding(locale$labels$month[2]), "UTF-8")
+
+  expect_identical(
+    year_month_day_parse(x, format = format, locale = locale),
+    year_month_day(2019, 2, 1)
+  )
+})
+
 test_that("parsing NA returns NA", {
   expect_identical(
     year_month_day_parse(NA_character_),

--- a/tests/testthat/test-gregorian-year-month-day.R
+++ b/tests/testthat/test-gregorian-year-month-day.R
@@ -251,6 +251,21 @@ test_that("can use a different locale with UTF-8 strings", {
   )
 })
 
+test_that("`format` argument is translated to UTF-8", {
+  x <- enc2utf8("fév 2019-05-19")
+
+  format <- "fév %Y-%m-%d"
+  format <- iconv(format, to = "latin1")
+
+  expect_identical(Encoding(x), "UTF-8")
+  expect_identical(Encoding(format), "latin1")
+
+  expect_identical(
+    year_month_day_parse(x, format = format),
+    year_month_day(2019, 5, 19)
+  )
+})
+
 test_that("parsing NA returns NA", {
   expect_identical(
     year_month_day_parse(NA_character_),

--- a/tests/testthat/test-naive-time.R
+++ b/tests/testthat/test-naive-time.R
@@ -234,8 +234,8 @@ test_that("can use a different locale", {
 })
 
 test_that("`x` is translated to UTF-8", {
-  x <- c("février 05, 2019", "mars 22, 2020")
-  x <- iconv(x, to = "latin1")
+  x <- "f\u00E9vrier 05, 2019"
+  x <- iconv(x, from = "UTF-8", to = "latin1")
 
   locale <- clock_locale("fr")
   format <- "%B %d, %Y"
@@ -245,7 +245,7 @@ test_that("`x` is translated to UTF-8", {
 
   expect_identical(
     naive_parse(x, format = format, precision = "day", locale = locale),
-    as_naive(year_month_day(c(2019, 2020), c(2, 3), c(5, 22)))
+    as_naive(year_month_day(2019, 2, 5))
   )
 })
 

--- a/tests/testthat/test-naive-time.R
+++ b/tests/testthat/test-naive-time.R
@@ -233,6 +233,22 @@ test_that("can use a different locale", {
   )
 })
 
+test_that("`x` is translated to UTF-8", {
+  x <- c("février 05, 2019", "mars 22, 2020")
+  x <- iconv(x, to = "latin1")
+
+  locale <- clock_locale("fr")
+  format <- "%B %d, %Y"
+
+  expect_identical(Encoding(x[1]), "latin1")
+  expect_identical(Encoding(locale$labels$month[2]), "UTF-8")
+
+  expect_identical(
+    naive_parse(x, format = format, precision = "day", locale = locale),
+    as_naive(year_month_day(c(2019, 2020), c(2, 3), c(5, 22)))
+  )
+})
+
 test_that("%z is completely ignored, but is required to be parsed correctly if specified", {
   x <- "2019-01-01 00:00:00+0100"
   y <- "2019-01-01 00:00:00"

--- a/tests/testthat/test-zoned-time.R
+++ b/tests/testthat/test-zoned-time.R
@@ -214,6 +214,22 @@ test_that("all failures uses UTC time zone (#162)", {
   )
 })
 
+test_that("`x` is translated to UTF-8", {
+  x <- "2019-février-01 01:02:03-05:00[America/New_York]"
+  x <- iconv(x, to = "latin1")
+
+  locale <- clock_locale("fr")
+  format <- "%Y-%B-%d %H:%M:%S%Ez[%Z]"
+
+  expect_identical(Encoding(x), "latin1")
+  expect_identical(Encoding(locale$labels$month[2]), "UTF-8")
+
+  expect_identical(
+    zoned_parse_complete(x, format = format, locale = locale),
+    as_zoned(as_naive(year_month_day(2019, 2, 1, 1, 2, 3)), "America/New_York")
+  )
+})
+
 # ------------------------------------------------------------------------------
 # zoned_parse_abbrev()
 
@@ -354,6 +370,22 @@ test_that("NA parses correctly", {
   expect_identical(
     zoned_parse_abbrev(NA_character_, "America/New_York", precision = "nanosecond"),
     as_zoned(as_sys(duration_nanoseconds(NA)), "America/New_York")
+  )
+})
+
+test_that("`x` is translated to UTF-8", {
+  x <- "2019-février-01 01:02:03-05:00[EST]"
+  x <- iconv(x, to = "latin1")
+
+  locale <- clock_locale("fr")
+  format <- "%Y-%B-%d %H:%M:%S%Ez[%Z]"
+
+  expect_identical(Encoding(x), "latin1")
+  expect_identical(Encoding(locale$labels$month[2]), "UTF-8")
+
+  expect_identical(
+    zoned_parse_abbrev(x, "America/New_York", format = format, locale = locale),
+    as_zoned(as_naive(year_month_day(2019, 2, 1, 1, 2, 3)), "America/New_York")
   )
 })
 

--- a/tests/testthat/test-zoned-time.R
+++ b/tests/testthat/test-zoned-time.R
@@ -215,8 +215,8 @@ test_that("all failures uses UTC time zone (#162)", {
 })
 
 test_that("`x` is translated to UTF-8", {
-  x <- "2019-février-01 01:02:03-05:00[America/New_York]"
-  x <- iconv(x, to = "latin1")
+  x <- "2019-f\u00E9vrier-01 01:02:03-05:00[America/New_York]"
+  x <- iconv(x, from = "UTF-8", to = "latin1")
 
   locale <- clock_locale("fr")
   format <- "%Y-%B-%d %H:%M:%S%Ez[%Z]"
@@ -374,8 +374,8 @@ test_that("NA parses correctly", {
 })
 
 test_that("`x` is translated to UTF-8", {
-  x <- "2019-février-01 01:02:03-05:00[EST]"
-  x <- iconv(x, to = "latin1")
+  x <- "2019-f\u00E9vrier-01 01:02:03-05:00[EST]"
+  x <- iconv(x, from = "UTF-8", to = "latin1")
 
   locale <- clock_locale("fr")
   format <- "%Y-%B-%d %H:%M:%S%Ez[%Z]"


### PR DESCRIPTION
Negligible performance impact, which is good

``` r
library(clock)


x <- rep("2019-01-01", 1e6)
bench::mark(year_month_day_parse(x), iterations = 10)

# before
#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.
#> # A tibble: 1 x 6
#>   expression                   min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>              <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 year_month_day_parse(x)    387ms    396ms      2.45      12MB     3.92

# after
#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.
#> # A tibble: 1 x 6
#>   expression                   min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>              <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 year_month_day_parse(x)    386ms    391ms      2.46      12MB     3.94


x <- rep("2019-01-01 01:02:03", 1e6)
bench::mark(naive_parse(x), iterations = 10)

# before
#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.
#> # A tibble: 1 x 6
#>   expression          min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>     <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 naive_parse(x)    580ms    594ms      1.68    7.71MB     3.02

# after
#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.
#> # A tibble: 1 x 6
#>   expression          min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>     <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 naive_parse(x)    579ms    592ms      1.68    7.71MB     3.03
```

<sup>Created on 2021-02-24 by the [reprex package](https://reprex.tidyverse.org) (v1.0.0)</sup>