### PR TITLE
Floor double Dates before casting to integer with `duration_days()`

### DIFF
--- a/R/date.R
+++ b/R/date.R
@@ -2,6 +2,9 @@
 as_sys_time.Date <- function(x) {
   names <- names(x)
   x <- unstructure(x)
+  if (is.double(x)) {
+    x <- floor(x)
+  }
   x <- duration_days(x)
   new_sys_time_from_fields(x, PRECISION_DAY, names)
 }

--- a/tests/testthat/test-date.R
+++ b/tests/testthat/test-date.R
@@ -6,6 +6,26 @@ test_that("invalid dates must be resolved when converting to a Date", {
 })
 
 # ------------------------------------------------------------------------------
+# as_sys_time()
+
+test_that("converting to sys-time floors fractional dates (#191)", {
+  x <- new_date(c(-0.5, 1.5))
+  y <- new_date(c(-1, 1))
+
+  expect_identical(as_sys_time(x), as_sys_time(y))
+  expect_identical(as.Date(as_sys_time(x)), y)
+})
+
+test_that("converting to sys-time works with integer storage dates", {
+  # These can occur from `seq.Date(from, to, length.out)`
+  x <- structure(1L, class = "Date")
+  y <- new_date(1)
+
+  expect_identical(as_sys_time(x), as_sys_time(y))
+  expect_identical(as.Date(as_sys_time(x)), y)
+})
+
+# ------------------------------------------------------------------------------
 # as_weekday()
 
 test_that("can convert to weekday", {


### PR DESCRIPTION
Closes #191 

We are generally a bit more lax with Dates and POSIXct. For POSIXct, we already floor to get rid of fractional seconds, so this just adds similar behavior for Dates and fractional days.