### PR TITLE
Pass `double`s to `pow()` for Solaris

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # clock (development version)
 
+* Fixed a Solaris ambiguous behavior issue from calling `pow(int, int)`.
+
 * Linking against cpp11 0.2.7 is now required to fix a rare memory leak issue.
 
 # clock 0.1.0

--- a/src/duration.cpp
+++ b/src/duration.cpp
@@ -1140,7 +1140,10 @@ inline
 cpp11::writable::doubles
 duration_as_double_impl(const ClockDuration& x) {
   // Usually 2^53 - 1
-  static int64_t DOUBLE_MAX_NO_LOSS = static_cast<int64_t>(pow(FLT_RADIX, DBL_MANT_DIG) - 1);
+  // Pass `double`s to `pow()` for Solaris, where `pow(int, int)` is undefined
+  static double DOUBLE_FLT_RADIX = static_cast<double>(FLT_RADIX);
+  static double DOUBLE_DBL_MANT_DIG = static_cast<double>(DBL_MANT_DIG);
+  static int64_t DOUBLE_MAX_NO_LOSS = static_cast<int64_t>(std::pow(DOUBLE_FLT_RADIX, DOUBLE_DBL_MANT_DIG) - 1);
   static int64_t DOUBLE_MIN_NO_LOSS = -DOUBLE_MAX_NO_LOSS;
 
   const r_ssize size = x.size();


### PR DESCRIPTION
Since calling `pow(int, int)` is undefined on that platform and results in:

```cpp
duration.cpp:1143:87: error: call of overloaded ‘pow(int, int)’ is ambiguous
   static int64_t DOUBLE_MAX_NO_LOSS = static_cast<int64_t>(pow(FLT_RADIX, DBL_MANT_DIG) - 1);
                                                                                       ^
In file included from /usr/include/math.h:15:0,
                 from /opt/csw/include/c++/5.2.0/cmath:44,
                 from /opt/csw/include/c++/5.2.0/random:38,
                 from /opt/csw/include/c++/5.2.0/bits/stl_algo.h:66,
                 from /opt/csw/include/c++/5.2.0/algorithm:62,
                 from ../inst/include/date/date.h:44,
                 from clock.h:5,
                 from duration.cpp:1:
/opt/csw/lib/gcc/i386-pc-solaris2.10/5.2.0/include-fixed/iso/math_iso.h:204:21: note: candidate: long double std::pow(long double, long double)
  inline long double pow(long double __X, long double __Y) { return
                     ^
/opt/csw/lib/gcc/i386-pc-solaris2.10/5.2.0/include-fixed/iso/math_iso.h:171:15: note: candidate: float std::pow(float, float)
  inline float pow(float __X, float __Y) { return __powf(__X, __Y); }
               ^
/opt/csw/lib/gcc/i386-pc-solaris2.10/5.2.0/include-fixed/iso/math_iso.h:72:15: note: candidate: double std::pow(double, double)
 extern double pow __P((double, double));
```