### PR TITLE
Use error bullets for `nonexistent`, `ambiguous`, and `invalid` errors

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # clock (development version)
 
+* Errors resulting from invalid dates or nonexistent/ambiguous times are now
+  a little nicer to read through the usage of an info bullet (#200).
+
 * Fixed a Solaris ambiguous behavior issue from calling `pow(int, int)`.
 
 * Linking against cpp11 0.2.7 is now required to fix a rare memory leak issue.

--- a/R/utils.R
+++ b/R/utils.R
@@ -157,10 +157,13 @@ stop_clock_unsupported_zoned_time_op <- function(op) {
 
 # Thrown from C++
 stop_clock_invalid_date <- function(i) {
-  message <- paste0(
-    "Invalid date found at location ", i, ". ",
-    "Resolve invalid date issues by specifying the `invalid` argument."
+  header <- paste0(
+    "Invalid date found at location ", i, "."
   )
+  bullet <- format_error_bullets(
+    c(i = "Resolve invalid date issues by specifying the `invalid` argument.")
+  )
+  message <- paste0(header, "\n", bullet)
   stop_clock(message, "clock_error_invalid_date")
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -181,10 +181,13 @@ stop_clock_nonexistent_time <- function(i) {
 
 # Thrown from C++
 stop_clock_ambiguous_time <- function(i) {
-  message <- paste0(
-    "Ambiguous time due to daylight saving time at location ", i, ". ",
-    "Resolve ambiguous time issues by specifying the `ambiguous` argument."
+  header <- paste0(
+    "Ambiguous time due to daylight saving time at location ", i, "."
   )
+  bullet <- format_error_bullets(
+    c(i = "Resolve ambiguous time issues by specifying the `ambiguous` argument.")
+  )
+  message <- paste0(header, "\n", bullet)
   stop_clock(message, "clock_error_ambiguous_time")
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -169,10 +169,13 @@ stop_clock_invalid_date <- function(i) {
 
 # Thrown from C++
 stop_clock_nonexistent_time <- function(i) {
-  message <- paste0(
-    "Nonexistent time due to daylight saving time at location ", i, ". ",
-    "Resolve nonexistent time issues by specifying the `nonexistent` argument."
+  header <- paste0(
+    "Nonexistent time due to daylight saving time at location ", i, "."
   )
+  bullet <- format_error_bullets(
+    c(i = "Resolve nonexistent time issues by specifying the `nonexistent` argument.")
+  )
+  message <- paste0(header, "\n", bullet)
   stop_clock(message, "clock_error_nonexistent_time")
 }
 

--- a/tests/testthat/_snaps/date.md
+++ b/tests/testthat/_snaps/date.md
@@ -129,7 +129,8 @@
 
 # can handle invalid dates
 
-    Invalid date found at location 2. Resolve invalid date issues by specifying the `invalid` argument.
+    Invalid date found at location 2.
+    i Resolve invalid date issues by specifying the `invalid` argument.
 
 # <date> op <duration>
 

--- a/tests/testthat/_snaps/gregorian-year-day.md
+++ b/tests/testthat/_snaps/gregorian-year-day.md
@@ -84,5 +84,6 @@
 
 # throws known classed error
 
-    Invalid date found at location 1. Resolve invalid date issues by specifying the `invalid` argument.
+    Invalid date found at location 1.
+    i Resolve invalid date issues by specifying the `invalid` argument.
 

--- a/tests/testthat/_snaps/gregorian-year-month-day.md
+++ b/tests/testthat/_snaps/gregorian-year-month-day.md
@@ -118,5 +118,6 @@
 
 # throws known classed error
 
-    Invalid date found at location 1. Resolve invalid date issues by specifying the `invalid` argument.
+    Invalid date found at location 1.
+    i Resolve invalid date issues by specifying the `invalid` argument.
 

--- a/tests/testthat/_snaps/naive-time.md
+++ b/tests/testthat/_snaps/naive-time.md
@@ -40,7 +40,8 @@
 
 # can resolve nonexistent issues
 
-    Nonexistent time due to daylight saving time at location 1. Resolve nonexistent time issues by specifying the `nonexistent` argument.
+    Nonexistent time due to daylight saving time at location 1.
+    i Resolve nonexistent time issues by specifying the `nonexistent` argument.
 
 # `ambiguous` is validated
 

--- a/tests/testthat/_snaps/naive-time.md
+++ b/tests/testthat/_snaps/naive-time.md
@@ -28,15 +28,18 @@
 
 # can resolve ambiguous issues - character
 
-    Ambiguous time due to daylight saving time at location 1. Resolve ambiguous time issues by specifying the `ambiguous` argument.
+    Ambiguous time due to daylight saving time at location 1.
+    i Resolve ambiguous time issues by specifying the `ambiguous` argument.
 
 # can resolve ambiguous issues - zoned-time
 
-    Ambiguous time due to daylight saving time at location 2. Resolve ambiguous time issues by specifying the `ambiguous` argument.
+    Ambiguous time due to daylight saving time at location 2.
+    i Resolve ambiguous time issues by specifying the `ambiguous` argument.
 
 ---
 
-    Ambiguous time due to daylight saving time at location 1. Resolve ambiguous time issues by specifying the `ambiguous` argument.
+    Ambiguous time due to daylight saving time at location 1.
+    i Resolve ambiguous time issues by specifying the `ambiguous` argument.
 
 # can resolve nonexistent issues
 

--- a/tests/testthat/_snaps/posixt.md
+++ b/tests/testthat/_snaps/posixt.md
@@ -168,7 +168,8 @@
 
 # can handle invalid dates
 
-    Invalid date found at location 2. Resolve invalid date issues by specifying the `invalid` argument.
+    Invalid date found at location 2.
+    i Resolve invalid date issues by specifying the `invalid` argument.
 
 # can handle nonexistent times
 

--- a/tests/testthat/_snaps/posixt.md
+++ b/tests/testthat/_snaps/posixt.md
@@ -132,7 +132,8 @@
 
 ---
 
-    Ambiguous time due to daylight saving time at location 1. Resolve ambiguous time issues by specifying the `ambiguous` argument.
+    Ambiguous time due to daylight saving time at location 1.
+    i Resolve ambiguous time issues by specifying the `ambiguous` argument.
 
 # failure to parse throws a warning
 
@@ -163,7 +164,8 @@
 
 # `ambiguous = x` retains the offset of `x` if applicable
 
-    Ambiguous time due to daylight saving time at location 1. Resolve ambiguous time issues by specifying the `ambiguous` argument.
+    Ambiguous time due to daylight saving time at location 1.
+    i Resolve ambiguous time issues by specifying the `ambiguous` argument.
 
 # `zone` is required
 
@@ -181,7 +183,8 @@
 
 # can handle ambiguous times
 
-    Ambiguous time due to daylight saving time at location 1. Resolve ambiguous time issues by specifying the `ambiguous` argument.
+    Ambiguous time due to daylight saving time at location 1.
+    i Resolve ambiguous time issues by specifying the `ambiguous` argument.
 
 # <posixt> op <duration>
 

--- a/tests/testthat/_snaps/posixt.md
+++ b/tests/testthat/_snaps/posixt.md
@@ -1,6 +1,7 @@
 # can handle nonexistent times resulting from grouping
 
-    Nonexistent time due to daylight saving time at location 1. Resolve nonexistent time issues by specifying the `nonexistent` argument.
+    Nonexistent time due to daylight saving time at location 1.
+    i Resolve nonexistent time issues by specifying the `nonexistent` argument.
 
 # can't group by finer precisions
 
@@ -12,7 +13,8 @@
 
 # flooring can handle nonexistent times
 
-    Nonexistent time due to daylight saving time at location 2. Resolve nonexistent time issues by specifying the `nonexistent` argument.
+    Nonexistent time due to daylight saving time at location 2.
+    i Resolve nonexistent time issues by specifying the `nonexistent` argument.
 
 # `origin` is floored to the precision of `precision` with a potential warning before rounding
 
@@ -125,7 +127,8 @@
 
 # can resolve ambiguity and nonexistent times
 
-    Nonexistent time due to daylight saving time at location 1. Resolve nonexistent time issues by specifying the `nonexistent` argument.
+    Nonexistent time due to daylight saving time at location 1.
+    i Resolve nonexistent time issues by specifying the `nonexistent` argument.
 
 ---
 
@@ -173,7 +176,8 @@
 
 # can handle nonexistent times
 
-    Nonexistent time due to daylight saving time at location 1. Resolve nonexistent time issues by specifying the `nonexistent` argument.
+    Nonexistent time due to daylight saving time at location 1.
+    i Resolve nonexistent time issues by specifying the `nonexistent` argument.
 
 # can handle ambiguous times
 


### PR DESCRIPTION
Closes #200 