### PR TITLE
Generate warnings when formatting naive-times with `%Z` or `%z`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -38,6 +38,9 @@
 
 * Errors resulting from invalid dates or nonexistent/ambiguous times are now
   a little nicer to read through the usage of an info bullet (#200).
+  
+* Formatting a naive-time with `%Z` or `%z` now warns that there were
+  format failures (#204).
 
 * Fixed a Solaris ambiguous behavior issue from calling `pow(int, int)`.
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -208,7 +208,7 @@ warn_clock <- function(message, class = character()) {
 # Thrown from C++
 warn_clock_parse_failures <- function(n, first) {
   if (n == 0) {
-    abort("Internal error: warning thrown with zero parse failures.")
+    abort("Internal error: warning thrown with zero failures.")
   } else if (n == 1) {
     message <- paste0(
       "Failed to parse 1 string at location ", first, ". ",
@@ -222,6 +222,25 @@ warn_clock_parse_failures <- function(n, first) {
   }
 
   warn_clock(message, "clock_warning_parse_failures")
+}
+
+# Thrown from C++
+warn_clock_format_failures <- function(n, first) {
+  if (n == 0) {
+    abort("Internal error: warning thrown with zero failures.")
+  } else if (n == 1) {
+    message <- paste0(
+      "Failed to format 1 string at location ", first, ". ",
+      "Returning `NA` at that location."
+    )
+  } else {
+    message <- paste0(
+      "Failed to format ", n, " strings, beginning at location ", first, ". ",
+      "Returning `NA` at the locations where there were format failures."
+    )
+  }
+
+  warn_clock(message, "clock_warning_format_failures")
 }
 
 # ------------------------------------------------------------------------------

--- a/src/failure.h
+++ b/src/failure.h
@@ -1,0 +1,73 @@
+#ifndef CLOCK_FAILURE_H
+#define CLOCK_FAILURE_H
+
+#include "clock.h"
+
+// -----------------------------------------------------------------------------
+
+namespace rclock {
+
+class failures {
+private:
+    r_ssize n_;
+    r_ssize first_;
+
+public:
+    CONSTCD11 failures() NOEXCEPT;
+
+    void write(r_ssize i);
+    CONSTCD11 bool any_failures() const NOEXCEPT;
+
+    void warn_parse() const;
+    void warn_format() const;
+};
+
+CONSTCD11
+inline
+failures::failures() NOEXCEPT
+    : n_(0),
+      first_(0)
+    {}
+
+inline
+void
+failures::write(r_ssize i) {
+    if (n_ == 0) {
+        first_ = i;
+    }
+    ++n_;
+}
+
+CONSTCD11
+inline
+bool
+failures::any_failures() const NOEXCEPT {
+    return n_ > 0;
+}
+
+inline
+void
+failures::warn_parse() const {
+    cpp11::writable::integers n(1);
+    cpp11::writable::integers first(1);
+    n[0] = (int) n_;
+    first[0] = (int) first_ + 1;
+    auto r_warn = cpp11::package("clock")["warn_clock_parse_failures"];
+    r_warn(n, first);
+}
+
+inline
+void
+failures::warn_format() const {
+  cpp11::writable::integers n(1);
+  cpp11::writable::integers first(1);
+  n[0] = (int) n_;
+  first[0] = (int) first_ + 1;
+  auto r_warn = cpp11::package("clock")["warn_clock_format_failures"];
+  r_warn(n, first);
+}
+
+} // namespace rclock
+
+// -----------------------------------------------------------------------------
+#endif // CLOCK_FAILURE_H

--- a/src/format.cpp
+++ b/src/format.cpp
@@ -6,6 +6,7 @@
 #include "check.h"
 #include "zone.h"
 #include "locale.h"
+#include "failure.h"
 #include <sstream>
 #include <locale>
 
@@ -1059,6 +1060,8 @@ cpp11::writable::strings format_time_point_impl(const ClockDuration& cd,
   std::string decimal_mark_string = decimal_mark[0];
   const char* decimal_mark_char = decimal_mark_string.c_str();
 
+  rclock::failures fail{};
+
   for (r_ssize i = 0; i < size; ++i) {
     if (cd.is_na(i)) {
       SET_STRING_ELT(out, i, r_chr_na);
@@ -1082,12 +1085,17 @@ cpp11::writable::strings format_time_point_impl(const ClockDuration& cd,
     );
 
     if (stream.fail()) {
+      fail.write(i);
       SET_STRING_ELT(out, i, r_chr_na);
       continue;
     }
 
     std::string str = stream.str();
     SET_STRING_ELT(out, i, Rf_mkCharLenCE(str.c_str(), str.size(), CE_UTF8));
+  }
+
+  if (fail.any_failures()) {
+    fail.warn_format();
   }
 
   return out;
@@ -1192,6 +1200,8 @@ cpp11::writable::strings format_zoned_time_impl(const ClockDuration& cd,
   const std::string decimal_mark_string = decimal_mark[0];
   const char* decimal_mark_char = decimal_mark_string.c_str();
 
+  rclock::failures fail{};
+
   for (r_ssize i = 0; i < size; ++i) {
     if (cd.is_na(i)) {
       SET_STRING_ELT(out, i, r_chr_na);
@@ -1227,12 +1237,17 @@ cpp11::writable::strings format_zoned_time_impl(const ClockDuration& cd,
     );
 
     if (stream.fail()) {
+      fail.write(i);
       SET_STRING_ELT(out, i, r_chr_na);
       continue;
     }
 
     std::string str = stream.str();
     SET_STRING_ELT(out, i, Rf_mkCharLenCE(str.c_str(), str.size(), CE_UTF8));
+  }
+
+  if (fail.any_failures()) {
+    fail.warn_format();
   }
 
   return out;

--- a/src/gregorian-year-month-day.cpp
+++ b/src/gregorian-year-month-day.cpp
@@ -5,6 +5,7 @@
 #include "enums.h"
 #include "get.h"
 #include "parse.h"
+#include "failure.h"
 #include "locale.h"
 #include "rcrd.h"
 
@@ -829,7 +830,7 @@ year_month_day_from_stream(std::istringstream& stream,
                            const std::pair<const std::string*, const std::string*>& ampm_names_pair,
                            const char& decimal_mark,
                            const r_ssize& i,
-                           rclock::parse_failures& failures,
+                           rclock::failures& fail,
                            Calendar& out) {
   using Duration = typename Calendar::duration;
   const r_ssize size = fmts.size();
@@ -863,7 +864,7 @@ year_month_day_from_stream(std::istringstream& stream,
     }
   }
 
-  failures.write(i);
+  fail.write(i);
   out.assign_na(i);
 }
 
@@ -877,7 +878,7 @@ year_month_day_from_stream(std::istringstream& stream,
                            const std::pair<const std::string*, const std::string*>& ampm_names_pair,
                            const char& decimal_mark,
                            const r_ssize& i,
-                           rclock::parse_failures& failures,
+                           rclock::failures& fail,
                            rclock::gregorian::y& out) {
   const r_ssize size = fmts.size();
 
@@ -904,7 +905,7 @@ year_month_day_from_stream(std::istringstream& stream,
     }
   }
 
-  failures.write(i);
+  fail.write(i);
   out.assign_na(i);
 }
 
@@ -918,7 +919,7 @@ year_month_day_from_stream(std::istringstream& stream,
                            const std::pair<const std::string*, const std::string*>& ampm_names_pair,
                            const char& decimal_mark,
                            const r_ssize& i,
-                           rclock::parse_failures& failures,
+                           rclock::failures& fail,
                            rclock::gregorian::ym& out) {
   const r_ssize size = fmts.size();
 
@@ -945,7 +946,7 @@ year_month_day_from_stream(std::istringstream& stream,
     }
   }
 
-  failures.write(i);
+  fail.write(i);
   out.assign_na(i);
 }
 
@@ -959,7 +960,7 @@ year_month_day_from_stream(std::istringstream& stream,
                            const std::pair<const std::string*, const std::string*>& ampm_names_pair,
                            const char& decimal_mark,
                            const r_ssize& i,
-                           rclock::parse_failures& failures,
+                           rclock::failures& fail,
                            rclock::gregorian::ymd& out) {
   const r_ssize size = fmts.size();
 
@@ -986,7 +987,7 @@ year_month_day_from_stream(std::istringstream& stream,
     }
   }
 
-  failures.write(i);
+  fail.write(i);
   out.assign_na(i);
 }
 
@@ -1000,7 +1001,7 @@ year_month_day_from_stream(std::istringstream& stream,
                            const std::pair<const std::string*, const std::string*>& ampm_names_pair,
                            const char& decimal_mark,
                            const r_ssize& i,
-                           rclock::parse_failures& failures,
+                           rclock::failures& fail,
                            rclock::gregorian::ymdh& out) {
   const r_ssize size = fmts.size();
 
@@ -1030,7 +1031,7 @@ year_month_day_from_stream(std::istringstream& stream,
     }
   }
 
-  failures.write(i);
+  fail.write(i);
   out.assign_na(i);
 }
 
@@ -1044,7 +1045,7 @@ year_month_day_from_stream(std::istringstream& stream,
                            const std::pair<const std::string*, const std::string*>& ampm_names_pair,
                            const char& decimal_mark,
                            const r_ssize& i,
-                           rclock::parse_failures& failures,
+                           rclock::failures& fail,
                            rclock::gregorian::ymdhm& out) {
   const r_ssize size = fmts.size();
 
@@ -1075,7 +1076,7 @@ year_month_day_from_stream(std::istringstream& stream,
     }
   }
 
-  failures.write(i);
+  fail.write(i);
   out.assign_na(i);
 }
 
@@ -1089,7 +1090,7 @@ year_month_day_from_stream(std::istringstream& stream,
                            const std::pair<const std::string*, const std::string*>& ampm_names_pair,
                            const char& decimal_mark,
                            const r_ssize& i,
-                           rclock::parse_failures& failures,
+                           rclock::failures& fail,
                            rclock::gregorian::ymdhms& out) {
   const r_ssize size = fmts.size();
 
@@ -1121,7 +1122,7 @@ year_month_day_from_stream(std::istringstream& stream,
     }
   }
 
-  failures.write(i);
+  fail.write(i);
   out.assign_na(i);
 }
 
@@ -1169,7 +1170,7 @@ year_month_day_parse_impl(const cpp11::strings& x,
     ampm_names
   );
 
-  rclock::parse_failures failures{};
+  rclock::failures fail{};
 
   std::istringstream stream;
 
@@ -1195,15 +1196,15 @@ year_month_day_parse_impl(const cpp11::strings& x,
       ampm_names_pair,
       dmark,
       i,
-      failures,
+      fail,
       out
     );
   }
 
   vmaxset(vmax);
 
-  if (failures.any_failures()) {
-    failures.warn();
+  if (fail.any_failures()) {
+    fail.warn_parse();
   }
 
   return out.to_list();

--- a/src/parse.h
+++ b/src/parse.h
@@ -81,60 +81,6 @@ read(std::basic_istream<CharT, Traits>& is,
 
 namespace rclock {
 
-class parse_failures {
-private:
-    r_ssize n_;
-    r_ssize first_;
-
-public:
-    CONSTCD11 parse_failures() NOEXCEPT;
-
-    void write(r_ssize i);
-    CONSTCD11 bool any_failures() const NOEXCEPT;
-    void warn() const;
-};
-
-CONSTCD11
-inline
-parse_failures::parse_failures() NOEXCEPT
-    : n_(0),
-      first_(0)
-    {}
-
-inline
-void
-parse_failures::write(r_ssize i) {
-    if (n_ == 0) {
-        first_ = i;
-    }
-    ++n_;
-}
-
-CONSTCD11
-inline
-bool
-parse_failures::any_failures() const NOEXCEPT {
-    return n_ > 0;
-}
-
-inline
-void
-parse_failures::warn() const {
-    cpp11::writable::integers n(1);
-    cpp11::writable::integers first(1);
-    n[0] = (int) n_;
-    first[0] = (int) first_ + 1;
-    auto r_warn = cpp11::package("clock")["warn_clock_parse_failures"];
-    r_warn(n, first);
-}
-
-} // namespace rclock
-
-
-// -----------------------------------------------------------------------------
-
-namespace rclock {
-
 template <class CharT, class Traits, class Duration, class Alloc = std::allocator<CharT>>
 std::basic_istream<CharT, Traits>&
 from_stream(std::basic_istream<CharT, Traits>& is,

--- a/src/time-point.cpp
+++ b/src/time-point.cpp
@@ -4,6 +4,7 @@
 #include "rcrd.h"
 #include "duration.h"
 #include "parse.h"
+#include "failure.h"
 #include "locale.h"
 #include <sstream>
 
@@ -107,7 +108,7 @@ time_point_parse_one(std::istringstream& stream,
                      const std::pair<const std::string*, const std::string*>& ampm_names_pair,
                      const char& dmark,
                      const r_ssize& i,
-                     rclock::parse_failures& failures,
+                     rclock::failures& fail,
                      ClockDuration& out) {
   using Duration = typename ClockDuration::duration;
   const r_ssize size = fmts.size();
@@ -135,7 +136,7 @@ time_point_parse_one(std::istringstream& stream,
     }
   }
 
-  failures.write(i);
+  fail.write(i);
   out.assign_na(i);
 }
 
@@ -183,7 +184,7 @@ time_point_parse_impl(const cpp11::strings& x,
     ampm_names
   );
 
-  rclock::parse_failures failures{};
+  rclock::failures fail{};
 
   std::istringstream stream;
 
@@ -209,15 +210,15 @@ time_point_parse_impl(const cpp11::strings& x,
       ampm_names_pair,
       dmark,
       i,
-      failures,
+      fail,
       out
     );
   }
 
   vmaxset(vmax);
 
-  if (failures.any_failures()) {
-    failures.warn();
+  if (fail.any_failures()) {
+    fail.warn_parse();
   }
 
   return out.to_list();

--- a/src/zoned-time.cpp
+++ b/src/zoned-time.cpp
@@ -5,6 +5,7 @@
 #include "rcrd.h"
 #include "zone.h"
 #include "parse.h"
+#include "failure.h"
 #include "locale.h"
 
 // -----------------------------------------------------------------------------
@@ -435,7 +436,7 @@ zoned_time_parse_complete_one(std::istringstream& stream,
                               const std::pair<const std::string*, const std::string*>& ampm_names_pair,
                               const char& dmark,
                               const r_ssize& i,
-                              rclock::parse_failures& failures,
+                              rclock::failures& fail,
                               std::string& zone,
                               const date::time_zone*& p_time_zone,
                               ClockDuration& fields) {
@@ -509,7 +510,7 @@ zoned_time_parse_complete_one(std::istringstream& stream,
     return;
   }
 
-  failures.write(i);
+  fail.write(i);
   fields.assign_na(i);
 }
 
@@ -556,7 +557,7 @@ zoned_time_parse_complete_impl(const cpp11::strings& x,
     ampm_names
   );
 
-  rclock::parse_failures failures{};
+  rclock::failures fail{};
 
   std::string zone;
   const date::time_zone* p_time_zone = NULL;
@@ -585,7 +586,7 @@ zoned_time_parse_complete_impl(const cpp11::strings& x,
       ampm_names_pair,
       dmark,
       i,
-      failures,
+      fail,
       zone,
       p_time_zone,
       fields
@@ -594,8 +595,8 @@ zoned_time_parse_complete_impl(const cpp11::strings& x,
 
   vmaxset(vmax);
 
-  if (failures.any_failures()) {
-    failures.warn();
+  if (fail.any_failures()) {
+    fail.warn_parse();
   }
 
   if (zone.empty()) {
@@ -651,7 +652,7 @@ zoned_time_parse_abbrev_one(std::istringstream& stream,
                             const std::pair<const std::string*, const std::string*>& ampm_names_pair,
                             const char& dmark,
                             const r_ssize& i,
-                            rclock::parse_failures& failures,
+                            rclock::failures& fail,
                             const date::time_zone*& p_time_zone,
                             ClockDuration& fields) {
   using Duration = typename ClockDuration::duration;
@@ -725,7 +726,7 @@ zoned_time_parse_abbrev_one(std::istringstream& stream,
     return;
   }
 
-  failures.write(i);
+  fail.write(i);
   fields.assign_na(i);
 }
 
@@ -773,7 +774,7 @@ zoned_time_parse_abbrev_impl(const cpp11::strings& x,
     ampm_names
   );
 
-  rclock::parse_failures failures{};
+  rclock::failures fail{};
 
   std::istringstream stream;
 
@@ -799,7 +800,7 @@ zoned_time_parse_abbrev_impl(const cpp11::strings& x,
       ampm_names_pair,
       dmark,
       i,
-      failures,
+      fail,
       p_time_zone,
       fields
     );
@@ -807,8 +808,8 @@ zoned_time_parse_abbrev_impl(const cpp11::strings& x,
 
   vmaxset(vmax);
 
-  if (failures.any_failures()) {
-    failures.warn();
+  if (fail.any_failures()) {
+    fail.warn_parse();
   }
 
   return fields.to_list();

--- a/tests/testthat/_snaps/date.md
+++ b/tests/testthat/_snaps/date.md
@@ -118,6 +118,24 @@
     c: lun. déc. 31 00:00:00 2018
     %: %
 
+# formatting Dates with `%z` or `%Z` returns NA with a warning
+
+    Code
+      date_format(x, format = "%z")
+    Warning <clock_warning_format_failures>
+      Failed to format 1 string at location 1. Returning `NA` at that location.
+    Output
+      [1] NA
+
+---
+
+    Code
+      date_format(x, format = "%Z")
+    Warning <clock_warning_format_failures>
+      Failed to format 1 string at location 1. Returning `NA` at that location.
+    Output
+      [1] NA
+
 # failure to parse throws a warning
 
     Code

--- a/tests/testthat/_snaps/naive-time.md
+++ b/tests/testthat/_snaps/naive-time.md
@@ -26,6 +26,42 @@
       <time_point<naive><second>[1]>
       [1] NA
 
+# `%Z` generates format warnings (#204)
+
+    Code
+      format(x, format = "%Z")
+    Warning <clock_warning_format_failures>
+      Failed to format 1 string at location 1. Returning `NA` at that location.
+    Output
+      [1] NA
+
+---
+
+    Code
+      format(c(x, x), format = "%Z")
+    Warning <clock_warning_format_failures>
+      Failed to format 2 strings, beginning at location 1. Returning `NA` at the locations where there were format failures.
+    Output
+      [1] NA NA
+
+# `%z` generates format warnings (#204)
+
+    Code
+      format(x, format = "%z")
+    Warning <clock_warning_format_failures>
+      Failed to format 1 string at location 1. Returning `NA` at that location.
+    Output
+      [1] NA
+
+---
+
+    Code
+      format(c(x, x), format = "%z")
+    Warning <clock_warning_format_failures>
+      Failed to format 2 strings, beginning at location 1. Returning `NA` at the locations where there were format failures.
+    Output
+      [1] NA NA
+
 # can resolve ambiguous issues - character
 
     Ambiguous time due to daylight saving time at location 1.

--- a/tests/testthat/test-date.R
+++ b/tests/testthat/test-date.R
@@ -231,11 +231,14 @@ test_that("can format dates", {
   )
 })
 
-test_that("formatting Dates with `%z` or `%Z` returns NA", {
+test_that("formatting Dates with `%z` or `%Z` returns NA with a warning", {
   x <- as.Date("2018-01-01")
 
-  expect_identical(date_format(x, format = "%z"), NA_character_)
-  expect_identical(date_format(x, format = "%Z"), NA_character_)
+  expect_warning(date_format(x, format = "%z"), class = "clock_warning_format_failures")
+  expect_snapshot(date_format(x, format = "%z"))
+
+  expect_warning(date_format(x, format = "%Z"), class = "clock_warning_format_failures")
+  expect_snapshot(date_format(x, format = "%Z"))
 })
 
 # ------------------------------------------------------------------------------

--- a/tests/testthat/test-naive-time.R
+++ b/tests/testthat/test-naive-time.R
@@ -273,6 +273,27 @@ test_that("%Z is completely ignored", {
 })
 
 # ------------------------------------------------------------------------------
+# format()
+
+test_that("`%Z` generates format warnings (#204)", {
+  x <- naive_seconds(0)
+
+  expect_warning(format(x, format = "%Z"), class = "clock_warning_format_failures")
+
+  expect_snapshot(format(x, format = "%Z"))
+  expect_snapshot(format(c(x, x), format = "%Z"))
+})
+
+test_that("`%z` generates format warnings (#204)", {
+  x <- naive_seconds(0)
+
+  expect_warning(format(x, format = "%z"), class = "clock_warning_format_failures")
+
+  expect_snapshot(format(x, format = "%z"))
+  expect_snapshot(format(c(x, x), format = "%z"))
+})
+
+# ------------------------------------------------------------------------------
 # as_zoned_time()
 
 test_that("can convert non-ambiguous/nonexistent times to zoned time", {


### PR DESCRIPTION
Closes #204 