### PR TITLE
Fix condition expectations in prevision of testthat breaking change

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -27,6 +27,8 @@
   as_date_time(x, "America/New_York")
   #> [1] "2019-01-01 00:00:59 EST" "2019-01-01 00:01:00 EST"
   ```
+  
+* Preemptively updated tests related to upcoming changes in testthat (#236).
 
 # clock 0.3.0
 

--- a/tests/testthat/test-date.R
+++ b/tests/testthat/test-date.R
@@ -311,12 +311,12 @@ test_that("parsing into a date if you requested to parse time components rounds 
 })
 
 test_that("parsing fails when undocumented rounding behavior would result in invalid 60 second component (#230) (undocumented)", {
-  expect_identical(
-    expect_warning(
+  expect_warning(
+    expect_identical(
       date_parse("2019-01-01 01:01:59.550", format = "%Y-%m-%d %H:%M:%6S"),
-      class = "clock_warning_parse_failures"
+      new_date(NA_real_)
     ),
-    new_date(NA_real_)
+    class = "clock_warning_parse_failures"
   )
 })
 

--- a/tests/testthat/test-gregorian-year-month-day.R
+++ b/tests/testthat/test-gregorian-year-month-day.R
@@ -222,9 +222,11 @@ test_that("multiple formats can be provided", {
 test_that("failure to parse results in `NA`", {
   x <- "2020-01-ohno"
 
-  expect_identical(
-    expect_warning(year_month_day_parse(x)),
-    year_month_day(NA, NA, NA)
+  expect_warning(
+    expect_identical(
+      year_month_day_parse(x),
+      year_month_day(NA, NA, NA)
+    )
   )
 })
 

--- a/tests/testthat/test-naive-time.R
+++ b/tests/testthat/test-naive-time.R
@@ -180,9 +180,11 @@ test_that("parsing day components with second precision uses midnight as time", 
 test_that("cannot parse invalid dates", {
   x <- "2019-02-31"
 
-  expect_identical(
-    expect_warning(naive_time_parse(x, precision = "day")),
-    naive_days(NA)
+  expect_warning(
+    expect_identical(
+      naive_time_parse(x, precision = "day"),
+      naive_days(NA)
+    )
   )
 
   expect_snapshot(naive_time_parse(x, precision = "day"))
@@ -201,9 +203,11 @@ test_that("can parse with multiple formats", {
 test_that("failure to parse results in NA", {
   x <- "2019-01-oh"
 
-  expect_identical(
-    expect_warning(naive_time_parse(x, format = "%Y-%m-%d", precision = "day")),
-    naive_days(NA)
+  expect_warning(
+    expect_identical(
+      naive_time_parse(x, format = "%Y-%m-%d", precision = "day"),
+      naive_days(NA)
+    )
   )
 })
 
@@ -255,9 +259,11 @@ test_that("%z is completely ignored, but is required to be parsed correctly if s
     naive_time_parse(x, format = "%Y-%m-%d %H:%M:%S%z"),
     as_naive_time(year_month_day(2019, 1, 1, 0, 0, 0))
   )
-  expect_identical(
-    expect_warning(naive_time_parse(y, format = "%Y-%m-%d %H:%M:%S%z")),
-    naive_seconds(NA)
+  expect_warning(
+    expect_identical(
+      naive_time_parse(y, format = "%Y-%m-%d %H:%M:%S%z"),
+      naive_seconds(NA)
+    )
   )
 })
 
@@ -302,12 +308,12 @@ test_that("parsing rounds parsed subsecond components more precise than the resu
 })
 
 test_that("parsing fails when undocumented rounding behavior would result in invalid 60 second component (#230) (undocumented)", {
-  expect_identical(
-    expect_warning(
+  expect_warning(
+    expect_identical(
       naive_time_parse("2019-01-01 01:01:59.550", format = "%Y-%m-%d %H:%M:%6S", precision = "second"),
-      class = "clock_warning_parse_failures"
+      as_naive_time(year_month_day(NA, NA, NA, NA, NA, NA))
     ),
-    as_naive_time(year_month_day(NA, NA, NA, NA, NA, NA))
+    class = "clock_warning_parse_failures"
   )
 })
 

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -8,7 +8,9 @@ test_that("POSIXt time zones are standardized as expected", {
 
   # Unknown if this can happen, but we handle it anyways
   expect_snapshot(posixt_tzone_standardize(character()))
-  expect_identical(expect_warning(posixt_tzone_standardize(character())), "")
+  expect_warning(
+    expect_identical(posixt_tzone_standardize(character()), "")
+  )
 
   expect_snapshot_error(posixt_tzone_standardize(1))
 })

--- a/tests/testthat/test-zoned-time.R
+++ b/tests/testthat/test-zoned-time.R
@@ -117,9 +117,11 @@ test_that("cannot parse nonexistent time", {
 
   x <- "1970-04-26 02:30:00-05:00[America/New_York]"
 
-  expect_identical(
-    expect_warning(zoned_time_parse_complete(x)),
-    as_zoned_time(naive_seconds(NA), zone)
+  expect_warning(
+    expect_identical(
+      zoned_time_parse_complete(x),
+      as_zoned_time(naive_seconds(NA), zone)
+    )
   )
 
   expect_snapshot(zoned_time_parse_complete(x))
@@ -149,9 +151,11 @@ test_that("offset must align with unique offset", {
   # Should be `-05:00`
   x <- "2019-01-01 01:02:03-03:00[America/New_York]"
 
-  expect_identical(
-    expect_warning(zoned_time_parse_complete(x)),
-    as_zoned_time(naive_seconds(NA), zone)
+  expect_warning(
+    expect_identical(
+      zoned_time_parse_complete(x),
+      as_zoned_time(naive_seconds(NA), zone)
+    )
   )
 
   expect_snapshot(zoned_time_parse_complete(x))
@@ -166,9 +170,11 @@ test_that("offset must align with one of two possible ambiguous offsets", {
     "1970-10-25 01:30:00-06:00[America/New_York]"
   )
 
-  expect_identical(
-    expect_warning(zoned_time_parse_complete(x)),
-    as_zoned_time(naive_seconds(c(NA, NA)), zone)
+  expect_warning(
+    expect_identical(
+      zoned_time_parse_complete(x),
+      as_zoned_time(naive_seconds(c(NA, NA)), zone)
+    )
   )
 
   expect_snapshot(zoned_time_parse_complete(x))
@@ -208,9 +214,11 @@ test_that("all `NA`s uses UTC time zone (#162)", {
 })
 
 test_that("all failures uses UTC time zone (#162)", {
-  expect_identical(
-    expect_warning(zoned_time_parse_complete(c("foo", "bar"))),
-    as_zoned_time(naive_seconds(c(NA, NA)), "UTC")
+  expect_warning(
+    expect_identical(
+      zoned_time_parse_complete(c("foo", "bar")),
+      as_zoned_time(naive_seconds(c(NA, NA)), "UTC")
+    )
   )
 })
 
@@ -242,9 +250,12 @@ test_that("leftover subseconds result in a parse failure", {
   # This defaults to `%6S`, which parses `01.123` then stops,
   # leaving a `8` for `%z` to parse, resulting in a failure. Because everything
   # fails, we get a UTC time zone.
-  expect_identical(
-    expect_warning(zoned_time_parse_complete(x, precision = "millisecond"), class = "clock_warning_parse_failures"),
-    as_zoned_time(naive_seconds(NA) + duration_milliseconds(NA), zone = "UTC")
+  expect_warning(
+    expect_identical(
+      zoned_time_parse_complete(x, precision = "millisecond"),
+      as_zoned_time(naive_seconds(NA) + duration_milliseconds(NA), zone = "UTC")
+    ),
+    class = "clock_warning_parse_failures"
   )
 })
 
@@ -263,12 +274,12 @@ test_that("parsing fails when undocumented rounding behavior would result in inv
 
   # Requesting `%6S` parses the full `59.550`, which is immediately rounded to `60` which looks invalid.
   # The correct way to do this is to parse the milliseconds, then round.
-  expect_identical(
-    expect_warning(
+  expect_warning(
+    expect_identical(
       zoned_time_parse_complete(x, precision = "second", format = "%Y-%m-%d %H:%M:%6S%Ez[%Z]"),
-      class = "clock_warning_parse_failures"
+      as_zoned_time(as_naive_time(year_month_day(NA, NA, NA, NA, NA, NA)), zone = "UTC")
     ),
-    as_zoned_time(as_naive_time(year_month_day(NA, NA, NA, NA, NA, NA)), zone = "UTC")
+    class = "clock_warning_parse_failures"
   )
 })
 
@@ -322,28 +333,32 @@ test_that("abbreviation is used to resolve ambiguity", {
 })
 
 test_that("nonexistent times are NAs", {
-  expect_identical(
-    expect_warning(
-      zoned_time_parse_abbrev("1970-04-26 02:30:00 EST", "America/New_York")
-    ),
-    as_zoned_time(sys_seconds(NA), "America/New_York")
+  expect_warning(
+    expect_identical(
+      zoned_time_parse_abbrev("1970-04-26 02:30:00 EST", "America/New_York"),
+      as_zoned_time(sys_seconds(NA), "America/New_York")
+    )
   )
 })
 
 test_that("abbreviation must match the one implied from naive + time zone name lookup", {
   x <- "1970-01-01 00:00:00 FOOBAR"
 
-  expect_identical(
-    expect_warning(zoned_time_parse_abbrev(x, "America/New_York")),
-    as_zoned_time(sys_days(NA), "America/New_York")
+  expect_warning(
+    expect_identical(
+      zoned_time_parse_abbrev(x, "America/New_York"),
+      as_zoned_time(sys_days(NA), "America/New_York")
+    )
   )
 
   # Should be EST
   x <- "1970-01-01 00:00:00 EDT"
 
-  expect_identical(
-    expect_warning(zoned_time_parse_abbrev(x, "America/New_York")),
-    as_zoned_time(sys_days(NA), "America/New_York")
+  expect_warning(
+    expect_identical(
+      zoned_time_parse_abbrev(x, "America/New_York"),
+      as_zoned_time(sys_days(NA), "America/New_York")
+    )
   )
 
   expect_snapshot(zoned_time_parse_abbrev(x, "America/New_York"))


### PR DESCRIPTION
We are planning a breaking change to the condition expectations in testthat release (see NEWS item in https://github.com/r-lib/testthat/pull/1401). This PR implements a preventive fix that works with and without the breaking change.

There is no hurry to get this fix on CRAN since we are skipping one released version of testthat before going through with the change.
