### PR TITLE
Implement `<duration> %/% <duration>`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # clock (development version)
 
+* Integer division is now defined for two duration objects through
+  `<duration> %/% <duration>`. This always returns an integer vector, so be
+  aware that using very precise duration objects (like nanoseconds) can easily
+  generate a division result that is outside the range of an integer. In that
+  case, an `NA` is returned with a warning.
+
 # clock 0.5.0
 
 * New `date_time_parse_RFC_3339()` and `sys_time_parse_RFC_3339()` for parsing

--- a/R/cpp11.R
+++ b/R/cpp11.R
@@ -32,6 +32,10 @@ duration_modulus_cpp <- function(x, y, precision_int) {
   .Call(`_clock_duration_modulus_cpp`, x, y, precision_int)
 }
 
+duration_integer_divide_cpp <- function(x, y, precision_int) {
+  .Call(`_clock_duration_integer_divide_cpp`, x, y, precision_int)
+}
+
 duration_scalar_multiply_cpp <- function(x, y, precision_int) {
   .Call(`_clock_duration_scalar_multiply_cpp`, x, y, precision_int)
 }

--- a/src/cpp11.cpp
+++ b/src/cpp11.cpp
@@ -62,6 +62,13 @@ extern "C" SEXP _clock_duration_modulus_cpp(SEXP x, SEXP y, SEXP precision_int) 
   END_CPP11
 }
 // duration.cpp
+cpp11::writable::integers duration_integer_divide_cpp(cpp11::list_of<cpp11::integers> x, cpp11::list_of<cpp11::integers> y, const cpp11::integers& precision_int);
+extern "C" SEXP _clock_duration_integer_divide_cpp(SEXP x, SEXP y, SEXP precision_int) {
+  BEGIN_CPP11
+    return cpp11::as_sexp(duration_integer_divide_cpp(cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::integers>>>(x), cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::integers>>>(y), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(precision_int)));
+  END_CPP11
+}
+// duration.cpp
 cpp11::writable::list duration_scalar_multiply_cpp(cpp11::list_of<cpp11::integers> x, const cpp11::integers& y, const cpp11::integers& precision_int);
 extern "C" SEXP _clock_duration_scalar_multiply_cpp(SEXP x, SEXP y, SEXP precision_int) {
   BEGIN_CPP11
@@ -906,6 +913,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_clock_duration_floor_cpp",                                   (DL_FUNC) &_clock_duration_floor_cpp,                                    4},
     {"_clock_duration_has_common_precision_cpp",                    (DL_FUNC) &_clock_duration_has_common_precision_cpp,                     2},
     {"_clock_duration_helper_cpp",                                  (DL_FUNC) &_clock_duration_helper_cpp,                                   2},
+    {"_clock_duration_integer_divide_cpp",                          (DL_FUNC) &_clock_duration_integer_divide_cpp,                           3},
     {"_clock_duration_minus_cpp",                                   (DL_FUNC) &_clock_duration_minus_cpp,                                    3},
     {"_clock_duration_modulus_cpp",                                 (DL_FUNC) &_clock_duration_modulus_cpp,                                  3},
     {"_clock_duration_plus_cpp",                                    (DL_FUNC) &_clock_duration_plus_cpp,                                     3},

--- a/tests/testthat/_snaps/duration.md
+++ b/tests/testthat/_snaps/duration.md
@@ -188,3 +188,26 @@
 
     `x` must be a 'clock_duration'.
 
+# `<duration> / <duration>` is not allowed
+
+    Code
+      (expect_error(duration_years(1) / duration_years(2)))
+    Output
+      <error/vctrs_error_incompatible_op>
+      <duration<year>> / <duration<year>> is not permitted
+      Durations only support integer division. Did you want `%/%`?
+
+# `<duration> %/% <duration>` results in NA for OOB values
+
+    Code
+      out <- (numerator + one) %/% denominator
+    Warning <simpleWarning>
+      Conversion to integer is outside the range of an integer. `NA` values have been introduced, beginning at location 1.
+
+---
+
+    Code
+      out <- (-numerator - one) %/% denominator
+    Warning <simpleWarning>
+      Conversion to integer is outside the range of an integer. `NA` values have been introduced, beginning at location 1.
+

--- a/tests/testthat/test-duration.R
+++ b/tests/testthat/test-duration.R
@@ -281,6 +281,48 @@ test_that("precision: can only be called on durations", {
 })
 
 # ------------------------------------------------------------------------------
+# vec_arith()
+
+test_that("`<duration> / <duration>` is not allowed", {
+  expect_snapshot(
+    (expect_error(duration_years(1) / duration_years(2)))
+  )
+})
+
+test_that("`<duration> %/% <duration>` works", {
+  expect_identical(duration_years(5) %/% duration_years(2:3), c(2L, 1L))
+  expect_identical(duration_days(10) %/% duration_hours(7), 34L)
+})
+
+test_that("`<duration> %/% <duration>` propagates NA", {
+  expect_identical(duration_hours(NA) %/% duration_hours(1), NA_integer_)
+  expect_identical(duration_hours(1) %/% duration_hours(NA), NA_integer_)
+})
+
+test_that("`<duration> %/% <duration>` propagates names", {
+  expect_named(c(x = duration_hours(1)) %/% duration_hours(1:2), c("x", "x"))
+  expect_named(c(x = duration_hours(1)) %/% c(y = duration_hours(1)), "x")
+  expect_named(duration_hours(1) %/% c(y = duration_hours(1)), "y")
+})
+
+test_that("`<duration> %/% <duration>` results in NA for OOB values", {
+  skip_on_cran()
+
+  one <- duration_hours(1)
+  numerator <- duration_hours(.Machine$integer.max)
+  denominator <- duration_hours(1)
+
+  expect_identical(numerator %/% denominator, .Machine$integer.max)
+  expect_identical(-numerator %/% denominator, -.Machine$integer.max)
+
+  expect_snapshot(out <- (numerator + one) %/% denominator)
+  expect_identical(out, NA_integer_)
+
+  expect_snapshot(out <- (-numerator - one) %/% denominator)
+  expect_identical(out, NA_integer_)
+})
+
+# ------------------------------------------------------------------------------
 # vec_math()
 
 test_that("is.nan() works", {


### PR DESCRIPTION
We will need this for #266 for computing the time point differences. In most cases of the high level API, this should never have OOB issues, but it can if you use a finer precision like nanoseconds. For now that is okay, we can come back to this later and make a variant return a 64 bit integer type if we need to