### PR TITLE
Allow `"quarter"` in `calendar_count_between()` for `<year_month_*>`

### DIFF
--- a/R/calendar.R
+++ b/R/calendar.R
@@ -838,6 +838,7 @@ calendar_count_between.clock_calendar <- function(start,
   out
 }
 
+# Internal generic
 calendar_count_between_standardize_precision_n <- function(x, precision, n) {
   UseMethod("calendar_count_between_standardize_precision_n")
 }

--- a/R/calendar.R
+++ b/R/calendar.R
@@ -798,14 +798,13 @@ calendar_count_between.clock_calendar <- function(start,
 
   precision_int <- validate_precision_string(precision)
 
-  if (!calendar_is_valid_precision(start, precision_int)) {
-    abort(paste0(
-      "`precision` must be a valid '", calendar_name(start), "' precision."
-    ))
-  }
   if (calendar_precision_attribute(start) < precision_int) {
     abort("Precision of inputs must be at least as precise as `precision`.")
   }
+
+  args <- calendar_count_between_standardize_precision_n(start, precision, n)
+  precision <- args$precision
+  n <- args$n
 
   # Core computation to get the difference (pre-adjustment).
   # Result is an integer because it represents a count of duration units.
@@ -813,8 +812,8 @@ calendar_count_between.clock_calendar <- function(start,
 
   # Comparison proxy, truncated to avoid fields already when computing `out`
   args <- calendar_count_between_proxy_compare(start, end, precision)
-  start_proxy <- args[[1]]
-  end_proxy <- args[[2]]
+  start_proxy <- args$start
+  end_proxy <- args$end
 
   if (ncol(start_proxy) == 0L) {
     # vctrs bug with vec_compare()?
@@ -837,6 +836,10 @@ calendar_count_between.clock_calendar <- function(start,
   }
 
   out
+}
+
+calendar_count_between_standardize_precision_n <- function(x, precision, n) {
+  UseMethod("calendar_count_between_standardize_precision_n")
 }
 
 # Internal generic

--- a/R/date.R
+++ b/R/date.R
@@ -1780,6 +1780,8 @@ date_count_between <- function(start, end, precision, ..., n = 1L) {
 #'
 #' - `"year"`
 #'
+#' - `"quarter"`
+#'
 #' - `"month"`
 #'
 #' _Time point based counting:_
@@ -1792,6 +1794,9 @@ date_count_between <- function(start, end, precision, ..., n = 1L) {
 #'
 #' For dates, whether a calendar or time point is used is not all that
 #' important, but is is fairly important for date-times.
+#'
+#' @details
+#' `"quarter"` is equivalent to `"month"` precision with `n` set to `n * 3L`.
 #'
 #' @inheritSection calendar_count_between Comparison Direction
 #'
@@ -1807,6 +1812,7 @@ date_count_between <- function(start, end, precision, ..., n = 1L) {
 #'   One of:
 #'
 #'   - `"year"`
+#'   - `"quarter"`
 #'   - `"month"`
 #'   - `"week"`
 #'   - `"day"`
@@ -1829,6 +1835,10 @@ date_count_between <- function(start, end, precision, ..., n = 1L) {
 #' # Since 2020-05-04 occurs before the 5th of that month,
 #' # it gets a count of 239
 #' date_count_between(start, end, "month")
+#'
+#' # Number of "whole" quarters between (same as `"month"` with `n * 3`)
+#' date_count_between(start, end, "quarter")
+#' date_count_between(start, end, "month", n = 3)
 #'
 #' # Number of days between
 #' date_count_between(start, end, "day")
@@ -1899,7 +1909,7 @@ date_count_between.Date <- function(start, end, precision, ..., n = 1L) {
   # Designed to match `add_*()` functions to guarantee that
   # if `start <= end`, then `start + <count> <= end`
   allowed_precisions_calendar <- c(
-    PRECISION_YEAR, PRECISION_MONTH
+    PRECISION_YEAR, PRECISION_QUARTER, PRECISION_MONTH
   )
   allowed_precisions_naive_time <- c(
     PRECISION_WEEK, PRECISION_DAY

--- a/R/gregorian-year-day.R
+++ b/R/gregorian-year-day.R
@@ -956,6 +956,20 @@ calendar_count_between.clock_year_day <- function(start,
   NextMethod()
 }
 
+calendar_count_between_standardize_precision_n.clock_year_day <- function(x,
+                                                                          precision,
+                                                                          n) {
+  precision_int <- validate_precision_string(precision)
+
+  allowed_precisions <- c(PRECISION_YEAR)
+
+  if (!(precision_int %in% allowed_precisions)) {
+    abort("`precision` must be one of: 'year'.")
+  }
+
+  list(precision = precision, n = n)
+}
+
 calendar_count_between_compute.clock_year_day <- function(start,
                                                           end,
                                                           precision) {
@@ -966,7 +980,7 @@ calendar_count_between_compute.clock_year_day <- function(start,
     return(out)
   }
 
-  abort("`precision` must be one of: 'year'.")
+  abort("Internal error: `precision` should be 'year' at this point.")
 }
 
 calendar_count_between_proxy_compare.clock_year_day <- function(start,

--- a/R/gregorian-year-month-day.R
+++ b/R/gregorian-year-month-day.R
@@ -1224,6 +1224,9 @@ calendar_end.clock_year_month_day <- function(x, precision) {
 #' It counts the number of `precision` units between `start` and `end`
 #' (i.e., the number of years or months).
 #'
+#' @details
+#' `"quarter"` is equivalent to `"month"` precision with `n` set to `n * 3L`.
+#'
 #' @inheritParams calendar-count-between
 #'
 #' @param start,end `[clock_year_month_day]`
@@ -1236,6 +1239,7 @@ calendar_end.clock_year_month_day <- function(x, precision) {
 #'   One of:
 #'
 #'   - `"year"`
+#'   - `"quarter"`
 #'   - `"month"`
 #'
 #' @inherit calendar-count-between return
@@ -1262,6 +1266,26 @@ calendar_count_between.clock_year_month_day <- function(start,
   NextMethod()
 }
 
+calendar_count_between_standardize_precision_n.clock_year_month_day <- function(x,
+                                                                                precision,
+                                                                                n) {
+  precision_int <- validate_precision_string(precision)
+
+  allowed_precisions <- c(PRECISION_YEAR, PRECISION_QUARTER, PRECISION_MONTH)
+
+  if (!(precision_int %in% allowed_precisions)) {
+    abort("`precision` must be one of: 'year', 'quarter', 'month'.")
+  }
+
+  if (precision_int == PRECISION_QUARTER) {
+    # See #270's comment for why this is well-defined
+    precision <- "month"
+    n <- n * 3L
+  }
+
+  list(precision = precision, n = n)
+}
+
 calendar_count_between_compute.clock_year_month_day <- function(start,
                                                                 end,
                                                                 precision) {
@@ -1278,7 +1302,7 @@ calendar_count_between_compute.clock_year_month_day <- function(start,
     return(out)
   }
 
-  abort("`precision` must be one of: 'year', 'month'.")
+  abort("Internal error: `precision` should be 'year' or 'month' at this point.")
 }
 
 calendar_count_between_proxy_compare.clock_year_month_day <- function(start,

--- a/R/gregorian-year-month-weekday.R
+++ b/R/gregorian-year-month-weekday.R
@@ -1116,6 +1116,8 @@ calendar_end.clock_year_month_weekday <- function(x, precision) {
 #' precision or finer, so this method is only defined for `"year"` and
 #' `"month"` precision year-month-weekday objects.
 #'
+#' `"quarter"` is equivalent to `"month"` precision with `n` set to `n * 3L`.
+#'
 #' @inheritParams calendar-count-between
 #'
 #' @param start,end `[clock_year_month_weekday]`
@@ -1128,6 +1130,7 @@ calendar_end.clock_year_month_weekday <- function(x, precision) {
 #'   One of:
 #'
 #'   - `"year"`
+#'   - `"quarter"`
 #'   - `"month"`
 #'
 #' @inherit calendar-count-between return
@@ -1152,6 +1155,12 @@ calendar_count_between.clock_year_month_weekday <- function(start,
                                                             ...,
                                                             n = 1L) {
   NextMethod()
+}
+
+calendar_count_between_standardize_precision_n.clock_year_month_weekday <- function(x,
+                                                                                    precision,
+                                                                                    n) {
+  calendar_count_between_standardize_precision_n.clock_year_month_day(x, precision, n)
 }
 
 calendar_count_between_compute.clock_year_month_weekday <- function(start,

--- a/R/iso-year-week-day.R
+++ b/R/iso-year-week-day.R
@@ -973,6 +973,20 @@ calendar_count_between.clock_iso_year_week_day <- function(start,
   NextMethod()
 }
 
+calendar_count_between_standardize_precision_n.clock_iso_year_week_day <- function(x,
+                                                                                   precision,
+                                                                                   n) {
+  precision_int <- validate_precision_string(precision)
+
+  allowed_precisions <- c(PRECISION_YEAR)
+
+  if (!(precision_int %in% allowed_precisions)) {
+    abort("`precision` must be one of: 'year'.")
+  }
+
+  list(precision = precision, n = n)
+}
+
 calendar_count_between_compute.clock_iso_year_week_day <- function(start,
                                                                    end,
                                                                    precision) {
@@ -983,7 +997,7 @@ calendar_count_between_compute.clock_iso_year_week_day <- function(start,
     return(out)
   }
 
-  abort("`precision` must be one of: 'year'.")
+  abort("Internal error: `precision` should be 'year' at this point.")
 }
 
 calendar_count_between_proxy_compare.clock_iso_year_week_day <- function(start,

--- a/R/posixt.R
+++ b/R/posixt.R
@@ -1873,6 +1873,8 @@ date_seq.POSIXt <- function(from,
 #'
 #' - `"year"`
 #'
+#' - `"quarter"`
+#'
 #' - `"month"`
 #'
 #' _Naive-time based counting:_
@@ -1893,6 +1895,9 @@ date_seq.POSIXt <- function(from,
 #'
 #' - `"second"`
 #'
+#' @details
+#' `"quarter"` is equivalent to `"month"` precision with `n` set to `n * 3L`.
+#'
 #' @inheritSection calendar_count_between Comparison Direction
 #'
 #' @inheritParams date_count_between
@@ -1907,6 +1912,7 @@ date_seq.POSIXt <- function(from,
 #'   One of:
 #'
 #'   - `"year"`
+#'   - `"quarter"`
 #'   - `"month"`
 #'   - `"week"`
 #'   - `"day"`
@@ -2011,7 +2017,7 @@ date_count_between.POSIXt <- function(start, end, precision, ..., n = 1L) {
   # Designed to match `add_*()` functions to guarantee that
   # if `start <= end`, then `start + <count> <= end`
   allowed_precisions_calendar <- c(
-    PRECISION_YEAR, PRECISION_MONTH
+    PRECISION_YEAR, PRECISION_QUARTER, PRECISION_MONTH
   )
   allowed_precisions_naive_time <- c(
     PRECISION_WEEK, PRECISION_DAY

--- a/R/quarterly-year-quarter-day.R
+++ b/R/quarterly-year-quarter-day.R
@@ -1115,6 +1115,20 @@ calendar_count_between.clock_year_quarter_day <- function(start,
   NextMethod()
 }
 
+calendar_count_between_standardize_precision_n.clock_year_quarter_day <- function(x,
+                                                                                  precision,
+                                                                                  n) {
+  precision_int <- validate_precision_string(precision)
+
+  allowed_precisions <- c(PRECISION_YEAR, PRECISION_QUARTER)
+
+  if (!(precision_int %in% allowed_precisions)) {
+    abort("`precision` must be one of: 'year', 'quarter'.")
+  }
+
+  list(precision = precision, n = n)
+}
+
 calendar_count_between_compute.clock_year_quarter_day <- function(start,
                                                                   end,
                                                                   precision) {
@@ -1131,7 +1145,7 @@ calendar_count_between_compute.clock_year_quarter_day <- function(start,
     return(out)
   }
 
-  abort("`precision` must be one of: 'year', 'quarter'.")
+  abort("Internal error: `precision` should be 'year' or 'quarter' at this point.")
 }
 
 calendar_count_between_proxy_compare.clock_year_quarter_day <- function(start,

--- a/man/date-count-between.Rd
+++ b/man/date-count-between.Rd
@@ -18,6 +18,7 @@ size.}
 One of:
 \itemize{
 \item \code{"year"}
+\item \code{"quarter"}
 \item \code{"month"}
 \item \code{"week"}
 \item \code{"day"}
@@ -50,6 +51,7 @@ These precisions convert to a year-month-day calendar and count while in that
 type.
 \itemize{
 \item \code{"year"}
+\item \code{"quarter"}
 \item \code{"month"}
 }
 
@@ -63,6 +65,9 @@ These precisions convert to a time point and count while in that type.
 
 For dates, whether a calendar or time point is used is not all that
 important, but is is fairly important for date-times.
+}
+\details{
+\code{"quarter"} is equivalent to \code{"month"} precision with \code{n} set to \code{n * 3L}.
 }
 \section{Comparison Direction}{
 
@@ -87,6 +92,10 @@ date_count_between(start, end, "year")
 # Since 2020-05-04 occurs before the 5th of that month,
 # it gets a count of 239
 date_count_between(start, end, "month")
+
+# Number of "whole" quarters between (same as `"month"` with `n * 3`)
+date_count_between(start, end, "quarter")
+date_count_between(start, end, "month", n = 3)
 
 # Number of days between
 date_count_between(start, end, "day")

--- a/man/posixt-count-between.Rd
+++ b/man/posixt-count-between.Rd
@@ -18,6 +18,7 @@ size.}
 One of:
 \itemize{
 \item \code{"year"}
+\item \code{"quarter"}
 \item \code{"month"}
 \item \code{"week"}
 \item \code{"day"}
@@ -58,6 +59,7 @@ These precisions convert to a year-month-day calendar and count while in that
 type.
 \itemize{
 \item \code{"year"}
+\item \code{"quarter"}
 \item \code{"month"}
 }
 
@@ -77,6 +79,9 @@ These precisions convert to a sys-time and count while in that type.
 \item \code{"minute"}
 \item \code{"second"}
 }
+}
+\details{
+\code{"quarter"} is equivalent to \code{"month"} precision with \code{n} set to \code{n * 3L}.
 }
 \section{Comparison Direction}{
 

--- a/man/year-month-day-count-between.Rd
+++ b/man/year-month-day-count-between.Rd
@@ -18,6 +18,7 @@ common size.}
 One of:
 \itemize{
 \item \code{"year"}
+\item \code{"quarter"}
 \item \code{"month"}
 }}
 
@@ -35,6 +36,9 @@ An integer representing the number of \code{precision} units between
 This is a year-month-day method for the \code{\link[=calendar_count_between]{calendar_count_between()}} generic.
 It counts the number of \code{precision} units between \code{start} and \code{end}
 (i.e., the number of years or months).
+}
+\details{
+\code{"quarter"} is equivalent to \code{"month"} precision with \code{n} set to \code{n * 3L}.
 }
 \examples{
 # Compute an individual's age in years

--- a/man/year-month-weekday-count-between.Rd
+++ b/man/year-month-weekday-count-between.Rd
@@ -18,6 +18,7 @@ common size.}
 One of:
 \itemize{
 \item \code{"year"}
+\item \code{"quarter"}
 \item \code{"month"}
 }}
 
@@ -40,6 +41,8 @@ generic. It counts the number of \code{precision} units between \code{start} and
 Remember that year-month-weekday is not comparable when it is \code{"day"}
 precision or finer, so this method is only defined for \code{"year"} and
 \code{"month"} precision year-month-weekday objects.
+
+\code{"quarter"} is equivalent to \code{"month"} precision with \code{n} set to \code{n * 3L}.
 }
 \examples{
 # Compute the number of months between two dates

--- a/tests/testthat/_snaps/calendar.md
+++ b/tests/testthat/_snaps/calendar.md
@@ -186,14 +186,6 @@
       <error/rlang_error>
       `end` must be a <clock_calendar>.
 
-# can't count with a precision that calendar doesn't use
-
-    Code
-      (expect_error(calendar_count_between(x, x, "quarter")))
-    Output
-      <error/rlang_error>
-      `precision` must be a valid 'iso_year_week_day' precision.
-
 # can't count with a precision finer than the calendar precision
 
     Code

--- a/tests/testthat/_snaps/date.md
+++ b/tests/testthat/_snaps/date.md
@@ -238,7 +238,7 @@
       (expect_error(date_count_between(x, x, "hour")))
     Output
       <error/rlang_error>
-      `precision` must be one of: 'year', 'month', 'week', 'day'.
+      `precision` must be one of: 'year', 'quarter', 'month', 'week', 'day'.
 
 # can't count between a Date and a POSIXt
 

--- a/tests/testthat/_snaps/gregorian-year-month-day.md
+++ b/tests/testthat/_snaps/gregorian-year-month-day.md
@@ -142,15 +142,7 @@
       (expect_error(calendar_count_between(x, x, "day")))
     Output
       <error/rlang_error>
-      `precision` must be one of: 'year', 'month'.
-
-# can't compute a quarter count
-
-    Code
-      (expect_error(calendar_count_between(x, x, "quarter")))
-    Output
-      <error/rlang_error>
-      `precision` must be a valid 'year_month_day' precision.
+      `precision` must be one of: 'year', 'quarter', 'month'.
 
 # only granular precisions are allowed
 

--- a/tests/testthat/_snaps/gregorian-year-month-weekday.md
+++ b/tests/testthat/_snaps/gregorian-year-month-weekday.md
@@ -126,14 +126,6 @@
 
     Computing the end of a 'year_month_weekday' with a precision equal to or more precise than 'day' is undefined.
 
-# can't compute a unsupported count precision
-
-    Code
-      (expect_error(calendar_count_between(x, x, "quarter")))
-    Output
-      <error/rlang_error>
-      `precision` must be a valid 'year_month_weekday' precision.
-
 # can't compare a 'year_month_weekday' with day precision!
 
     Code

--- a/tests/testthat/_snaps/posixt.md
+++ b/tests/testthat/_snaps/posixt.md
@@ -347,7 +347,7 @@
       (expect_error(date_count_between(x, x, "millisecond")))
     Output
       <error/rlang_error>
-      `precision` must be one of: 'year', 'month', 'week', 'day', 'hour', 'minute', 'second'.
+      `precision` must be one of: 'year', 'quarter', 'month', 'week', 'day', 'hour', 'minute', 'second'.
 
 # can't count between a POSIXt and a Date
 

--- a/tests/testthat/test-calendar.R
+++ b/tests/testthat/test-calendar.R
@@ -270,11 +270,6 @@ test_that("`end` must be a calendar", {
   expect_snapshot((expect_error(calendar_count_between(x, 1, "year"))))
 })
 
-test_that("can't count with a precision that calendar doesn't use", {
-  x <- iso_year_week_day(2019, 1, 1)
-  expect_snapshot((expect_error(calendar_count_between(x, x, "quarter"))))
-})
-
 test_that("can't count with a precision finer than the calendar precision", {
   x <- year_month_day(2019)
   expect_snapshot((expect_error(calendar_count_between(x, x, "month"))))

--- a/tests/testthat/test-date.R
+++ b/tests/testthat/test-date.R
@@ -532,11 +532,12 @@ test_that("golden test: ensure that we never allow components of `to` to differ 
 # ------------------------------------------------------------------------------
 # date_count_between()
 
-test_that("can compute precisions at year / month / week / day", {
+test_that("can compute precisions at year / quarter / month / week / day", {
   x <- date_build(2019, 1, 5)
 
   y <- date_build(2025, 1, c(4, 6))
   expect_identical(date_count_between(x, y, "year"), c(5L, 6L))
+  expect_identical(date_count_between(x, y, "quarter"), c(23L, 24L))
   expect_identical(date_count_between(x, y, "month"), c(71L, 72L))
 
   y <- date_build(2019, 1, c(25, 26))

--- a/tests/testthat/test-gregorian-year-month-day.R
+++ b/tests/testthat/test-gregorian-year-month-day.R
@@ -535,6 +535,24 @@ test_that("can compute year and month counts", {
   expect_identical(calendar_count_between(x, y, "month", n = 2), 7L)
 })
 
+test_that("can compute a quarter count", {
+  x <- year_month_day(2019, 1, 2)
+
+  y <- year_month_day(2019, 4, c(1, 3))
+  expect_identical(calendar_count_between(x, y, "quarter"), c(0L, 1L))
+  expect_identical(
+    calendar_count_between(x, y, "quarter"),
+    calendar_count_between(x, y, "month", n = 3L)
+  )
+
+  y <- year_month_day(2020, 4, c(1, 3))
+  expect_identical(calendar_count_between(x, y, "quarter", n = 2L), c(2L, 2L))
+  expect_identical(
+    calendar_count_between(x, y, "quarter", n = 2L),
+    calendar_count_between(x, y, "month", n = 6L)
+  )
+})
+
 test_that("can't compute a unsupported count precision", {
   x <- year_month_day(2019, 1, 1)
   expect_snapshot((expect_error(calendar_count_between(x, x, "day"))))
@@ -568,11 +586,6 @@ test_that("positive / negative counts are correct", {
   end <- year_month_day(1971, 03, 05)
   expect_identical(calendar_count_between(start, end, "year"), 0L)
   expect_identical(calendar_count_between(start, end, "month"), -11L)
-})
-
-test_that("can't compute a quarter count", {
-  x <- year_month_day(2019, 1, 1)
-  expect_snapshot((expect_error(calendar_count_between(x, x, "quarter"))))
 })
 
 # ------------------------------------------------------------------------------

--- a/tests/testthat/test-gregorian-year-month-weekday.R
+++ b/tests/testthat/test-gregorian-year-month-weekday.R
@@ -250,9 +250,22 @@ test_that("can compute year and month counts", {
   expect_identical(calendar_count_between(x, y, "month", n = 2), 7L)
 })
 
-test_that("can't compute a unsupported count precision", {
+test_that("can compute a quarter count", {
   x <- year_month_weekday(2019, 1)
-  expect_snapshot((expect_error(calendar_count_between(x, x, "quarter"))))
+
+  y <- year_month_weekday(2019, c(3, 5))
+  expect_identical(calendar_count_between(x, y, "quarter"), c(0L, 1L))
+  expect_identical(
+    calendar_count_between(x, y, "quarter"),
+    calendar_count_between(x, y, "month", n = 3L)
+  )
+
+  y <- year_month_weekday(2020, c(3, 5))
+  expect_identical(calendar_count_between(x, y, "quarter", n = 2L), c(2L, 2L))
+  expect_identical(
+    calendar_count_between(x, y, "quarter", n = 2L),
+    calendar_count_between(x, y, "month", n = 6L)
+  )
 })
 
 test_that("positive / negative counts are correct", {

--- a/tests/testthat/test-posixt.R
+++ b/tests/testthat/test-posixt.R
@@ -836,11 +836,12 @@ test_that("golden test: ensure that we never allow components of `to` to differ 
 # ------------------------------------------------------------------------------
 # date_count_between()
 
-test_that("can compute precisions at year / month / week / day / hour / minute / second", {
+test_that("can compute precisions at year / quarter / month / week / day / hour / minute / second", {
   x <- date_time_build(2019, 1, 5, 5, zone = "UTC")
 
   y <- date_time_build(2025, 1, c(4, 6), zone = "UTC")
   expect_identical(date_count_between(x, y, "year"), c(5L, 6L))
+  expect_identical(date_count_between(x, y, "quarter"), c(23L, 24L))
   expect_identical(date_count_between(x, y, "month"), c(71L, 72L))
 
   y <- date_time_build(2019, 1, c(25, 27), zone = "UTC")


### PR DESCRIPTION
Closes #270 

Rationale described in https://github.com/r-lib/clock/issues/270#issuecomment-984053954