### PR TITLE
Use more correct coercion path from sys-time to POSIXct

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # clock (development version)
 
+* The sys-time method for `as.POSIXct()` now correctly promotes to a precision
+  of at least seconds before attempting the conversion. This matches the
+  behavior of the naive-time method (#278).
+
 # clock 0.6.0
 
 * New `date_count_between()`, `calendar_count_between()`, and

--- a/R/naive-time.R
+++ b/R/naive-time.R
@@ -450,7 +450,7 @@ as_zoned_time.clock_naive_time <- function(x,
   zone <- zone_validate(zone)
 
   # Promote to at least seconds precision for `zoned_time`
-  x <- vec_cast(x, vec_ptype2(x, naive_seconds()))
+  x <- vec_cast(x, vec_ptype2(x, clock_empty_naive_time_second))
 
   size <- vec_size(x)
   precision <- time_point_precision_attribute(x)

--- a/R/posixt.R
+++ b/R/posixt.R
@@ -105,13 +105,8 @@ as.POSIXct.clock_calendar <- function(x,
 
 #' @export
 as.POSIXct.clock_sys_time <- function(x, tz = "", ...) {
-  zone <- zone_validate(tz)
-  # Promote to at least seconds precision for `POSIXt`
-  x <- vec_cast(x, vec_ptype2(x, clock_empty_sys_time_second))
-  x <- time_point_floor(x, "second")
-  seconds <- to_sys_seconds_from_sys_duration_fields_cpp(x)
-  names(seconds) <- clock_rcrd_names(x)
-  new_datetime(seconds, zone)
+  x <- as_zoned_time(x, zone = tz)
+  as.POSIXct(x)
 }
 
 #' @export
@@ -128,7 +123,10 @@ as.POSIXct.clock_naive_time <- function(x,
 as.POSIXct.clock_zoned_time <- function(x, ...) {
   zone <- zoned_time_zone_attribute(x)
   x <- as_sys_time(x)
-  as.POSIXct(x, tz = zone)
+  x <- time_point_floor(x, "second")
+  seconds <- to_sys_seconds_from_sys_duration_fields_cpp(x)
+  names(seconds) <- clock_rcrd_names(x)
+  new_datetime(seconds, zone)
 }
 
 # ------------------------------------------------------------------------------

--- a/R/posixt.R
+++ b/R/posixt.R
@@ -122,10 +122,14 @@ as.POSIXct.clock_naive_time <- function(x,
 #' @export
 as.POSIXct.clock_zoned_time <- function(x, ...) {
   zone <- zoned_time_zone_attribute(x)
+
   x <- as_sys_time(x)
   x <- time_point_floor(x, "second")
+
   seconds <- to_sys_seconds_from_sys_duration_fields_cpp(x)
+
   names(seconds) <- clock_rcrd_names(x)
+
   new_datetime(seconds, zone)
 }
 

--- a/R/posixt.R
+++ b/R/posixt.R
@@ -106,6 +106,8 @@ as.POSIXct.clock_calendar <- function(x,
 #' @export
 as.POSIXct.clock_sys_time <- function(x, tz = "", ...) {
   zone <- zone_validate(tz)
+  # Promote to at least seconds precision for `POSIXt`
+  x <- vec_cast(x, vec_ptype2(x, clock_empty_sys_time_second))
   x <- time_point_floor(x, "second")
   seconds <- to_sys_seconds_from_sys_duration_fields_cpp(x)
   names(seconds) <- clock_rcrd_names(x)

--- a/R/sys-time.R
+++ b/R/sys-time.R
@@ -375,7 +375,7 @@ as_zoned_time.clock_sys_time <- function(x, zone, ...) {
   zone <- zone_validate(zone)
 
   # Promote to at least seconds precision for `zoned_time`
-  x <- vec_cast(x, vec_ptype2(x, sys_seconds()))
+  x <- vec_cast(x, vec_ptype2(x, clock_empty_sys_time_second))
 
   precision <- time_point_precision_attribute(x)
   names <- clock_rcrd_names(x)

--- a/tests/testthat/test-posixt.R
+++ b/tests/testthat/test-posixt.R
@@ -97,6 +97,22 @@ test_that("casting to POSIXct floors components more precise than seconds (#205)
   )
 })
 
+test_that("casting to POSIXct with time point less precise than seconds works (#278)", {
+  x <- as_naive_time(year_month_day(2019, 1, 1, 1))
+
+  expect_identical(
+    as.POSIXct(x, "America/New_York"),
+    date_time_parse("2019-01-01 01:00:00", "America/New_York")
+  )
+
+  x <- as_sys_time(year_month_day(2019, 1, 1, 1))
+
+  expect_identical(
+    as.POSIXct(x, "America/New_York"),
+    date_time_parse("2018-12-31 20:00:00", "America/New_York")
+  )
+})
+
 # ------------------------------------------------------------------------------
 # as_weekday()
 


### PR DESCRIPTION
Closes #278 

This ensures we go through promotion to at least second precision by utilizing the existing `as_zoned_time()` method for sys-time, which already does that.