### PR TITLE
Allow `from > to` when `by > 0` in `seq()` methods

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # clock (development version)
 
+* `date_seq()` and the `seq()` methods for the calendar, time point, and
+  duration types now allow `from > to` when `by > 0`. This now results in a
+  size zero result rather than an error, which is more in line with
+  `rlang::seq2()` and generally has more useful programmatic properties (#282).
+
 * The sys-time method for `as.POSIXct()` now correctly promotes to a precision
   of at least seconds before attempting the conversion. This matches the
   behavior of the naive-time method (#278).

--- a/R/date.R
+++ b/R/date.R
@@ -1379,8 +1379,6 @@ date_end.Date <- function(x, precision, ..., invalid = NULL) {
 #'
 #'   A date or date-time to start the sequence from.
 #'
-#'   `from` is always included in the result.
-#'
 #' @param to `[Date(1) / POSIXct(1) / POSIXlt(1) / NULL]`
 #'
 #'   A date or date-time to stop the sequence at.
@@ -1391,10 +1389,6 @@ date_end.Date <- function(x, precision, ..., invalid = NULL) {
 #' @param by `[integer(1) / clock_duration(1) / NULL]`
 #'
 #'   The unit to increment the sequence by.
-#'
-#'   If `to < from`, then `by` must be positive.
-#'
-#'   If `to > from`, then `by` must be negative.
 #'
 #' @param total_size `[positive integer(1) / NULL]`
 #'
@@ -1438,8 +1432,6 @@ date_seq <- function(from,
 #'
 #'   A date to start the sequence from.
 #'
-#'   `from` is always included in the result.
-#'
 #' @param to `[Date(1) / NULL]`
 #'
 #'   A date to stop the sequence at.
@@ -1456,10 +1448,6 @@ date_seq <- function(from,
 #' @param by `[integer(1) / clock_duration(1) / NULL]`
 #'
 #'   The unit to increment the sequence by.
-#'
-#'   If `to < from`, then `by` must be positive.
-#'
-#'   If `to > from`, then `by` must be negative.
 #'
 #'   If `by` is an integer, it is equivalent to `duration_days(by)`.
 #'

--- a/R/duration.R
+++ b/R/duration.R
@@ -552,13 +552,17 @@ duration_rounder <- function(x, precision, n, rounder, verb, ...) {
 #' - `by`
 #' - Either `length.out` or `along.with`
 #'
+#' @details
+#' If `from > to` and `by > 0`, then the result will be length 0. This matches
+#' the behavior of [rlang::seq2()], and results in nicer theoretical
+#' properties when compared with throwing an error. Similarly, if `from < to`
+#' and `by < 0`, then the result will also be length 0.
+#'
 #' @inheritParams ellipsis::dots_empty
 #'
 #' @param from `[clock_duration(1)]`
 #'
 #'   A duration to start the sequence from.
-#'
-#'   `from` is always included in the result.
 #'
 #' @param to `[clock_duration(1) / NULL]`
 #'
@@ -572,10 +576,6 @@ duration_rounder <- function(x, precision, n, rounder, verb, ...) {
 #' @param by `[integer(1) / clock_duration(1) / NULL]`
 #'
 #'   The unit to increment the sequence by.
-#'
-#'   If `to < from`, then `by` must be positive.
-#'
-#'   If `to > from`, then `by` must be negative.
 #'
 #'   If `by` is an integer, it is transformed into a duration with the
 #'   precision of `from`.

--- a/R/posixt.R
+++ b/R/posixt.R
@@ -1653,8 +1653,6 @@ date_end.POSIXt <- function(x,
 #'
 #'   A date-time to start the sequence from.
 #'
-#'   `from` is always included in the result.
-#'
 #' @param to `[POSIXct(1) / POSIXlt(1) / NULL]`
 #'
 #'   A date-time to stop the sequence at.
@@ -1674,10 +1672,6 @@ date_end.POSIXt <- function(x,
 #' @param by `[integer(1) / clock_duration(1) / NULL]`
 #'
 #'   The unit to increment the sequence by.
-#'
-#'   If `to < from`, then `by` must be positive.
-#'
-#'   If `to > from`, then `by` must be negative.
 #'
 #'   If `by` is an integer, it is equivalent to `duration_seconds(by)`.
 #'

--- a/man/date-sequence.Rd
+++ b/man/date-sequence.Rd
@@ -10,9 +10,7 @@
 \arguments{
 \item{from}{\verb{[Date(1)]}
 
-A date to start the sequence from.
-
-\code{from} is always included in the result.}
+A date to start the sequence from.}
 
 \item{...}{These dots are for future extensions and must be empty.}
 
@@ -31,10 +29,6 @@ weakly monotonic sequence of dates.}
 \item{by}{\verb{[integer(1) / clock_duration(1) / NULL]}
 
 The unit to increment the sequence by.
-
-If \code{to < from}, then \code{by} must be positive.
-
-If \code{to > from}, then \code{by} must be negative.
 
 If \code{by} is an integer, it is equivalent to \code{duration_days(by)}.
 

--- a/man/date_seq.Rd
+++ b/man/date_seq.Rd
@@ -9,9 +9,7 @@ date_seq(from, ..., to = NULL, by = NULL, total_size = NULL)
 \arguments{
 \item{from}{\verb{[Date(1) / POSIXct(1) / POSIXlt(1)]}
 
-A date or date-time to start the sequence from.
-
-\code{from} is always included in the result.}
+A date or date-time to start the sequence from.}
 
 \item{...}{These dots are for future extensions and must be empty.}
 
@@ -24,11 +22,7 @@ the distance between \code{from} and \code{to} exactly.}
 
 \item{by}{\verb{[integer(1) / clock_duration(1) / NULL]}
 
-The unit to increment the sequence by.
-
-If \code{to < from}, then \code{by} must be positive.
-
-If \code{to > from}, then \code{by} must be negative.}
+The unit to increment the sequence by.}
 
 \item{total_size}{\verb{[positive integer(1) / NULL]}
 

--- a/man/posixt-sequence.Rd
+++ b/man/posixt-sequence.Rd
@@ -19,9 +19,7 @@
 \arguments{
 \item{from}{\verb{[POSIXct(1) / POSIXlt(1)]}
 
-A date-time to start the sequence from.
-
-\code{from} is always included in the result.}
+A date-time to start the sequence from.}
 
 \item{...}{These dots are for future extensions and must be empty.}
 
@@ -43,10 +41,6 @@ The time zone of \code{to} must match the time zone of \code{from} exactly.}
 \item{by}{\verb{[integer(1) / clock_duration(1) / NULL]}
 
 The unit to increment the sequence by.
-
-If \code{to < from}, then \code{by} must be positive.
-
-If \code{to > from}, then \code{by} must be negative.
 
 If \code{by} is an integer, it is equivalent to \code{duration_seconds(by)}.
 

--- a/man/seq.clock_duration.Rd
+++ b/man/seq.clock_duration.Rd
@@ -9,9 +9,7 @@
 \arguments{
 \item{from}{\verb{[clock_duration(1)]}
 
-A duration to start the sequence from.
-
-\code{from} is always included in the result.}
+A duration to start the sequence from.}
 
 \item{to}{\verb{[clock_duration(1) / NULL]}
 
@@ -25,10 +23,6 @@ the distance between \code{from} and \code{to} exactly.}
 \item{by}{\verb{[integer(1) / clock_duration(1) / NULL]}
 
 The unit to increment the sequence by.
-
-If \code{to < from}, then \code{by} must be positive.
-
-If \code{to > from}, then \code{by} must be negative.
 
 If \code{by} is an integer, it is transformed into a duration with the
 precision of \code{from}.
@@ -65,6 +59,12 @@ When calling \code{seq()}, exactly two of the following must be specified:
 \item \code{by}
 \item Either \code{length.out} or \code{along.with}
 }
+}
+\details{
+If \code{from > to} and \code{by > 0}, then the result will be length 0. This matches
+the behavior of \code{\link[rlang:seq2]{rlang::seq2()}}, and results in nicer theoretical
+properties when compared with throwing an error. Similarly, if \code{from < to}
+and \code{by < 0}, then the result will also be length 0.
 }
 \examples{
 seq(duration_days(0), duration_days(100), by = 5)

--- a/man/seq.clock_iso_year_week_day.Rd
+++ b/man/seq.clock_iso_year_week_day.Rd
@@ -28,10 +28,6 @@ the distance between \code{from} and \code{to} exactly.}
 
 The unit to increment the sequence by.
 
-If \code{to < from}, then \code{by} must be positive.
-
-If \code{to > from}, then \code{by} must be negative.
-
 If \code{by} is an integer, it is transformed into a duration with the
 precision of \code{from}.
 

--- a/man/seq.clock_time_point.Rd
+++ b/man/seq.clock_time_point.Rd
@@ -26,10 +26,6 @@ the distance between \code{from} and \code{to} exactly.}
 
 The unit to increment the sequence by.
 
-If \code{to < from}, then \code{by} must be positive.
-
-If \code{to > from}, then \code{by} must be negative.
-
 If \code{by} is an integer, it is transformed into a duration with the
 precision of \code{from}.
 

--- a/man/seq.clock_year_day.Rd
+++ b/man/seq.clock_year_day.Rd
@@ -26,10 +26,6 @@ the distance between \code{from} and \code{to} exactly.}
 
 The unit to increment the sequence by.
 
-If \code{to < from}, then \code{by} must be positive.
-
-If \code{to > from}, then \code{by} must be negative.
-
 If \code{by} is an integer, it is transformed into a duration with the
 precision of \code{from}.
 

--- a/man/seq.clock_year_month_day.Rd
+++ b/man/seq.clock_year_month_day.Rd
@@ -28,10 +28,6 @@ the distance between \code{from} and \code{to} exactly.}
 
 The unit to increment the sequence by.
 
-If \code{to < from}, then \code{by} must be positive.
-
-If \code{to > from}, then \code{by} must be negative.
-
 If \code{by} is an integer, it is transformed into a duration with the
 precision of \code{from}.
 

--- a/man/seq.clock_year_month_weekday.Rd
+++ b/man/seq.clock_year_month_weekday.Rd
@@ -28,10 +28,6 @@ the distance between \code{from} and \code{to} exactly.}
 
 The unit to increment the sequence by.
 
-If \code{to < from}, then \code{by} must be positive.
-
-If \code{to > from}, then \code{by} must be negative.
-
 If \code{by} is an integer, it is transformed into a duration with the
 precision of \code{from}.
 

--- a/man/seq.clock_year_quarter_day.Rd
+++ b/man/seq.clock_year_quarter_day.Rd
@@ -28,10 +28,6 @@ the distance between \code{from} and \code{to} exactly.}
 
 The unit to increment the sequence by.
 
-If \code{to < from}, then \code{by} must be positive.
-
-If \code{to > from}, then \code{by} must be negative.
-
 If \code{by} is an integer, it is transformed into a duration with the
 precision of \code{from}.
 

--- a/src/duration.cpp
+++ b/src/duration.cpp
@@ -1599,21 +1599,16 @@ duration_seq_to_by_impl(const ClockDuration& from,
   const Duration end = to[0];
   const Duration step = by[0];
 
-  // Base seq() requires negative `by` when creating a decreasing seq, so this
-  // helps be compatible with that.
-  if (start > end && step > Duration{0}) {
-    clock_abort("When `from` is greater than `to`, `by` must be negative.");
-  }
-  if (start < end && step < Duration{0}) {
-    clock_abort("When `from` is less than `to`, `by` must be positive.");
-  }
-
   // TODO: This can overflow with very far apart nanosecond durations
   const Rep num = end.count() - start.count();
   const Rep den = step.count();
   const Rep length_out = num / den + 1;
 
-  const r_ssize size = static_cast<r_ssize>(length_out);
+  // To match `rlang::seq2()`, which has nicer properties.
+  // i.e., when `start > end && step > 0` or `start < end && step < 0`.
+  const Rep length_out2 = std::max(length_out, Rep{0});
+
+  const r_ssize size = static_cast<r_ssize>(length_out2);
 
   ClockDuration out(size);
 

--- a/src/duration.cpp
+++ b/src/duration.cpp
@@ -1599,8 +1599,7 @@ duration_seq_to_by_impl(const ClockDuration& from,
   const Duration end = to[0];
   const Duration step = by[0];
 
-  // TODO: This can overflow with very far apart nanosecond durations
-  const Rep num = end.count() - start.count();
+  const Rep num = clock_safe_subtract(end.count(), start.count());
   const Rep den = step.count();
   const Rep length_out = num / den + 1;
 

--- a/src/duration.cpp
+++ b/src/duration.cpp
@@ -6,6 +6,7 @@
 #include "rcrd.h"
 #include <sstream>
 #include <cfloat>
+#include <algorithm>
 
 // -----------------------------------------------------------------------------
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -6,6 +6,7 @@
 #include <cmath>
 #include <cstdarg> // For `va_start()` and `va_end()`
 #include <cstdio> // For `vsnprintf()`
+#include <limits>
 
 // -----------------------------------------------------------------------------
 
@@ -120,6 +121,25 @@ r_list_deref_const(SEXP x) {
 #else
   return ((const SEXP*) DATAPTR_RO(x));
 #endif
+}
+
+// -----------------------------------------------------------------------------
+
+template <class T>
+static inline
+T clock_safe_subtract(T x, T y) {
+  static const T max = std::numeric_limits<T>::max();
+  static const T min = std::numeric_limits<T>::min();
+
+  if ((y > 0 && x < (min + y)) ||
+      (y < 0 && x > (max + y))) {
+    cpp11::stop(
+      "Internal error in `clock_safe_subtract()`: "
+      "Subtraction resulted in overflow or underflow."
+    );
+  }
+
+  return x - y;
 }
 
 // -----------------------------------------------------------------------------

--- a/tests/testthat/_snaps/duration.md
+++ b/tests/testthat/_snaps/duration.md
@@ -138,14 +138,6 @@
     These dots only exist to allow future extensions and should be empty.
     Did you misspecify an argument?
 
-# seq() validates from/to/by signs
-
-    When `from` is less than `to`, `by` must be positive.
-
----
-
-    When `from` is greater than `to`, `by` must be negative.
-
 # seq() enforces non-fractional results
 
     The supplied output size does not result in a non-fractional sequence between `from` and `to`.

--- a/tests/testthat/test-date.R
+++ b/tests/testthat/test-date.R
@@ -482,6 +482,18 @@ test_that("components of `from` more precise than `by` are restored", {
   )
 })
 
+test_that("seq() with `from > to && by > 0` or `from < to && by > 0` results in length 0 output (#282)", {
+  expect_identical(
+    date_seq(date_build(2019, 1, 2), to = date_build(2019, 1, 1), by = 1),
+    date_build(integer())
+  )
+
+  expect_identical(
+    date_seq(date_build(2019), to = date_build(2020), by = -1),
+    date_build(integer())
+  )
+})
+
 test_that("components of `to` more precise than `by` must match `from`", {
   expect_snapshot_error(date_seq(date_build(2019, 1, 1), to = date_build(2019, 2, 2), by = duration_months(1)))
   expect_snapshot_error(date_seq(date_build(2019, 1, 1), to = date_build(2019, 3, 1), by = duration_years(1)))

--- a/tests/testthat/test-duration.R
+++ b/tests/testthat/test-duration.R
@@ -156,14 +156,22 @@ test_that("seq() validates dots", {
   expect_snapshot_error(seq(duration_years(1), duration_years(1), 1, 1, 1, 1))
 })
 
-test_that("seq() validates from/to/by signs", {
-  expect_snapshot_error(seq(duration_years(1L), to = duration_years(2L), by = -1))
-  expect_snapshot_error(seq(duration_years(2L), to = duration_years(1L), by = 1))
-})
-
 test_that("seq() enforces non-fractional results", {
   expect_snapshot_error(seq(duration_years(1L), to = duration_years(2L), length.out = 3))
   expect_snapshot_error(seq(duration_years(1L), to = duration_years(2L), along.with = 1:3))
+})
+
+test_that("seq() works when from and to are identical", {
+  expect_identical(seq(duration_years(1L), to = duration_years(1L), by = 1), duration_years(1L))
+  expect_identical(seq(duration_years(1L), to = duration_years(1L), by = -1), duration_years(1L))
+})
+
+test_that("seq() with `from > to && by > 0` or `from < to && by > 0` results in length 0 output (#282)", {
+  expect_identical(seq(duration_years(2L), to = duration_years(1L), by = 1), duration_years())
+  expect_identical(seq(duration_years(5L), to = duration_years(1L), by = 1), duration_years())
+
+  expect_identical(seq(duration_years(1L), to = duration_years(2L), by = -1), duration_years())
+  expect_identical(seq(duration_years(1L), to = duration_years(5L), by = -1), duration_years())
 })
 
 test_that("seq(to, by) works", {

--- a/tests/testthat/test-posixt.R
+++ b/tests/testthat/test-posixt.R
@@ -802,6 +802,20 @@ test_that("components of `to` more precise than `by` must match `from`", {
   expect_snapshot_error(date_seq(date_time_build(2019, 1, 1, zone = zone), to = date_time_build(2019, 1, 2, zone = zone), by = duration_years(1)))
 })
 
+test_that("seq() with `from > to && by > 0` or `from < to && by > 0` results in length 0 output (#282)", {
+  zone <- "America/New_York"
+
+  expect_identical(
+    date_seq(date_time_build(2019, 1, 2, second = 1, zone = zone), to = date_time_build(2019, 1, 2, zone = zone), by = 1),
+    date_time_build(integer(), zone = zone)
+  )
+
+  expect_identical(
+    date_seq(date_time_build(2019, zone = zone), to = date_time_build(2020, zone = zone), by = -1),
+    date_time_build(integer(), zone = zone)
+  )
+})
+
 test_that("`to` must have same time zone as `by`", {
   expect_snapshot_error(date_seq(date_time_build(1970, zone = "UTC"), to = date_time_build(1970, zone = "America/New_York"), by = 1))
 })


### PR DESCRIPTION
Closes #282 

Also improves on potential overflow issues