### PR TITLE
Don't use `cat()` for formatting tests that may involve UTF-8

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # clock (development version)
 
+* Updated tests related to writing UTF-8 on Windows and testthat 3.1.2 (#287).
+
 * Updated all snapshot tests to use rlang 1.0.0 (#285).
 
 * `date_seq()` and the `seq()` methods for the calendar, time point, and

--- a/tests/testthat/_snaps/date.md
+++ b/tests/testthat/_snaps/date.md
@@ -50,73 +50,81 @@
 
 # can format dates
 
-    C: 20
-    y: 18
-    Y: 2018
-    b: Dec
-    h: Dec
-    B: December
-    m: 12
-    d: 31
-    a: Mon
-    A: Monday
-    w: 1
-    g: 19
-    G: 2019
-    V: 01
-    u: 1
-    U: 52
-    W: 53
-    j: 365
-    D: 12/31/18
-    x: 12/31/18
-    F: 2018-12-31
-    H: 00
-    I: 12
-    M: 00
-    S: 00
-    p: AM
-    R: 00:00
-    T: 00:00:00
-    X: 00:00:00
-    r: 12:00:00 AM
-    c: Mon Dec 31 00:00:00 2018
-    %: %
+    Code
+      vapply(X = formats, FUN = function(format) date_format(x, format = format),
+      FUN.VALUE = character(1))
+    Output
+                              C: %C                         y: %y 
+                            "C: 20"                       "y: 18" 
+                              Y: %Y                         b: %b 
+                          "Y: 2018"                      "b: Dec" 
+                              h: %h                         B: %B 
+                           "h: Dec"                 "B: December" 
+                              m: %m                         d: %d 
+                            "m: 12"                       "d: 31" 
+                              a: %a                         A: %A 
+                           "a: Mon"                   "A: Monday" 
+                              w: %w                         g: %g 
+                             "w: 1"                       "g: 19" 
+                              G: %G                         V: %V 
+                          "G: 2019"                       "V: 01" 
+                              u: %u                         U: %U 
+                             "u: 1"                       "U: 52" 
+                              W: %W                         j: %j 
+                            "W: 53"                      "j: 365" 
+                              D: %D                         x: %x 
+                      "D: 12/31/18"                 "x: 12/31/18" 
+                              F: %F                         H: %H 
+                    "F: 2018-12-31"                       "H: 00" 
+                              I: %I                         M: %M 
+                            "I: 12"                       "M: 00" 
+                              S: %S                         p: %p 
+                            "S: 00"                       "p: AM" 
+                              R: %R                         T: %T 
+                         "R: 00:00"                 "T: 00:00:00" 
+                              X: %X                         r: %r 
+                      "X: 00:00:00"              "r: 12:00:00 AM" 
+                              c: %c                         %: %% 
+      "c: Mon Dec 31 00:00:00 2018"                        "%: %" 
 
 ---
 
-    C: 20
-    y: 18
-    Y: 2018
-    b: déc.
-    h: déc.
-    B: décembre
-    m: 12
-    d: 31
-    a: lun.
-    A: lundi
-    w: 1
-    g: 19
-    G: 2019
-    V: 01
-    u: 1
-    U: 52
-    W: 53
-    j: 365
-    D: 12/31/18
-    x: 12/31/18
-    F: 2018-12-31
-    H: 00
-    I: 12
-    M: 00
-    S: 00
-    p: AM
-    R: 00:00
-    T: 00:00:00
-    X: 00:00:00
-    r: 12:00:00 AM
-    c: lun. déc. 31 00:00:00 2018
-    %: %
+    Code
+      vapply(X = formats, FUN = function(format) date_format(x, format = format,
+        locale = clock_locale("fr")), FUN.VALUE = character(1))
+    Output
+                                C: %C                           y: %y 
+                              "C: 20"                         "y: 18" 
+                                Y: %Y                           b: %b 
+                            "Y: 2018"                       "b: déc." 
+                                h: %h                           B: %B 
+                            "h: déc."                   "B: décembre" 
+                                m: %m                           d: %d 
+                              "m: 12"                         "d: 31" 
+                                a: %a                           A: %A 
+                            "a: lun."                      "A: lundi" 
+                                w: %w                           g: %g 
+                               "w: 1"                         "g: 19" 
+                                G: %G                           V: %V 
+                            "G: 2019"                         "V: 01" 
+                                u: %u                           U: %U 
+                               "u: 1"                         "U: 52" 
+                                W: %W                           j: %j 
+                              "W: 53"                        "j: 365" 
+                                D: %D                           x: %x 
+                        "D: 12/31/18"                   "x: 12/31/18" 
+                                F: %F                           H: %H 
+                      "F: 2018-12-31"                         "H: 00" 
+                                I: %I                           M: %M 
+                              "I: 12"                         "M: 00" 
+                                S: %S                           p: %p 
+                              "S: 00"                         "p: AM" 
+                                R: %R                           T: %T 
+                           "R: 00:00"                   "T: 00:00:00" 
+                                X: %X                           r: %r 
+                        "X: 00:00:00"                "r: 12:00:00 AM" 
+                                c: %c                           %: %% 
+      "c: lun. déc. 31 00:00:00 2018"                          "%: %" 
 
 # formatting Dates with `%z` or `%Z` returns NA with a warning
 

--- a/tests/testthat/_snaps/posixt.md
+++ b/tests/testthat/_snaps/posixt.md
@@ -75,79 +75,89 @@
 
 # can format date-times
 
-    C: 20
-    y: 18
-    Y: 2018
-    b: Dec
-    h: Dec
-    B: December
-    m: 12
-    d: 31
-    a: Mon
-    A: Monday
-    w: 1
-    g: 19
-    G: 2019
-    V: 01
-    u: 1
-    U: 52
-    W: 53
-    j: 365
-    D: 12/31/18
-    x: 12/31/18
-    F: 2018-12-31
-    H: 23
-    I: 11
-    M: 59
-    S: 59
-    p: PM
-    R: 23:59
-    T: 23:59:59
-    X: 23:59:59
-    r: 11:59:59 PM
-    c: Mon Dec 31 23:59:59 2018
-    %: %
-    z: -0500
-    Ez: -05:00
-    Z: America/New_York
+    Code
+      vapply(X = formats, FUN = function(format) date_format(x, format = format),
+      FUN.VALUE = character(1))
+    Output
+                              C: %C                         y: %y 
+                            "C: 20"                       "y: 18" 
+                              Y: %Y                         b: %b 
+                          "Y: 2018"                      "b: Dec" 
+                              h: %h                         B: %B 
+                           "h: Dec"                 "B: December" 
+                              m: %m                         d: %d 
+                            "m: 12"                       "d: 31" 
+                              a: %a                         A: %A 
+                           "a: Mon"                   "A: Monday" 
+                              w: %w                         g: %g 
+                             "w: 1"                       "g: 19" 
+                              G: %G                         V: %V 
+                          "G: 2019"                       "V: 01" 
+                              u: %u                         U: %U 
+                             "u: 1"                       "U: 52" 
+                              W: %W                         j: %j 
+                            "W: 53"                      "j: 365" 
+                              D: %D                         x: %x 
+                      "D: 12/31/18"                 "x: 12/31/18" 
+                              F: %F                         H: %H 
+                    "F: 2018-12-31"                       "H: 23" 
+                              I: %I                         M: %M 
+                            "I: 11"                       "M: 59" 
+                              S: %S                         p: %p 
+                            "S: 59"                       "p: PM" 
+                              R: %R                         T: %T 
+                         "R: 23:59"                 "T: 23:59:59" 
+                              X: %X                         r: %r 
+                      "X: 23:59:59"              "r: 11:59:59 PM" 
+                              c: %c                         %: %% 
+      "c: Mon Dec 31 23:59:59 2018"                        "%: %" 
+                              z: %z                       Ez: %Ez 
+                         "z: -0500"                  "Ez: -05:00" 
+                              Z: %Z 
+              "Z: America/New_York" 
 
 ---
 
-    C: 20
-    y: 18
-    Y: 2018
-    b: déc.
-    h: déc.
-    B: décembre
-    m: 12
-    d: 31
-    a: lun.
-    A: lundi
-    w: 1
-    g: 19
-    G: 2019
-    V: 01
-    u: 1
-    U: 52
-    W: 53
-    j: 365
-    D: 12/31/18
-    x: 12/31/18
-    F: 2018-12-31
-    H: 23
-    I: 11
-    M: 59
-    S: 59
-    p: PM
-    R: 23:59
-    T: 23:59:59
-    X: 23:59:59
-    r: 11:59:59 PM
-    c: lun. déc. 31 23:59:59 2018
-    %: %
-    z: -0500
-    Ez: -05:00
-    Z: America/New_York
+    Code
+      vapply(X = formats, FUN = function(format) date_format(x, format = format,
+        locale = clock_locale("fr")), FUN.VALUE = character(1))
+    Output
+                                C: %C                           y: %y 
+                              "C: 20"                         "y: 18" 
+                                Y: %Y                           b: %b 
+                            "Y: 2018"                       "b: déc." 
+                                h: %h                           B: %B 
+                            "h: déc."                   "B: décembre" 
+                                m: %m                           d: %d 
+                              "m: 12"                         "d: 31" 
+                                a: %a                           A: %A 
+                            "a: lun."                      "A: lundi" 
+                                w: %w                           g: %g 
+                               "w: 1"                         "g: 19" 
+                                G: %G                           V: %V 
+                            "G: 2019"                         "V: 01" 
+                                u: %u                           U: %U 
+                               "u: 1"                         "U: 52" 
+                                W: %W                           j: %j 
+                              "W: 53"                        "j: 365" 
+                                D: %D                           x: %x 
+                        "D: 12/31/18"                   "x: 12/31/18" 
+                                F: %F                           H: %H 
+                      "F: 2018-12-31"                         "H: 23" 
+                                I: %I                           M: %M 
+                              "I: 11"                         "M: 59" 
+                                S: %S                           p: %p 
+                              "S: 59"                         "p: PM" 
+                                R: %R                           T: %T 
+                           "R: 23:59"                   "T: 23:59:59" 
+                                X: %X                           r: %r 
+                        "X: 23:59:59"                "r: 11:59:59 PM" 
+                                c: %c                           %: %% 
+      "c: lun. déc. 31 23:59:59 2018"                          "%: %" 
+                                z: %z                         Ez: %Ez 
+                           "z: -0500"                    "Ez: -05:00" 
+                                Z: %Z 
+                "Z: America/New_York" 
 
 # can resolve ambiguity and nonexistent times
 

--- a/tests/testthat/helper-format.R
+++ b/tests/testthat/helper-format.R
@@ -1,5 +1,5 @@
 test_all_formats <- function(zone = TRUE) {
-  out <- paste(
+  out <- c(
     "C: %C",
     "y: %y",
     "Y: %Y",
@@ -31,19 +31,17 @@ test_all_formats <- function(zone = TRUE) {
     "X: %X",
     "r: %r",
     "c: %c",
-    "%: %%",
-    sep = "\n"
+    "%: %%"
   )
 
   if (!zone) {
     return(out)
   }
 
-  paste(
+  c(
     out,
     "z: %z",
     "Ez: %Ez",
-    "Z: %Z",
-    sep = "\n"
+    "Z: %Z"
   )
 }

--- a/tests/testthat/test-date.R
+++ b/tests/testthat/test-date.R
@@ -265,13 +265,21 @@ test_that("can convert to a month factor", {
 
 test_that("can format dates", {
   x <- as.Date("2018-12-31")
-  format <- test_all_formats(zone = FALSE)
+  formats <- test_all_formats(zone = FALSE)
 
-  expect_snapshot_output(
-    cat(date_format(x, format = format))
+  expect_snapshot(
+    vapply(
+      X = formats,
+      FUN = function(format) date_format(x, format = format),
+      FUN.VALUE = character(1)
+    )
   )
-  expect_snapshot_output(
-    cat(date_format(x, format = format, locale = clock_locale("fr")))
+  expect_snapshot(
+    vapply(
+      X = formats,
+      FUN = function(format) date_format(x, format = format, locale = clock_locale("fr")),
+      FUN.VALUE = character(1)
+    )
   )
 })
 

--- a/tests/testthat/test-posixt.R
+++ b/tests/testthat/test-posixt.R
@@ -293,13 +293,21 @@ test_that("default format is correct", {
 
 test_that("can format date-times", {
   x <- as.POSIXct("2018-12-31 23:59:59", "America/New_York")
-  format <- test_all_formats()
+  formats <- test_all_formats()
 
-  expect_snapshot_output(
-    cat(date_format(x, format = format))
+  expect_snapshot(
+    vapply(
+      X = formats,
+      FUN = function(format) date_format(x, format = format),
+      FUN.VALUE = character(1)
+    )
   )
-  expect_snapshot_output(
-    cat(date_format(x, format = format, locale = clock_locale("fr")))
+  expect_snapshot(
+    vapply(
+      X = formats,
+      FUN = function(format) date_format(x, format = format, locale = clock_locale("fr")),
+      FUN.VALUE = character(1)
+    )
   )
 })
 


### PR DESCRIPTION
Instead, we now just print them out normally, which hopefully will work

Follow up to #285 