### PR TITLE
fix: Unit tests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,7 +22,7 @@ Depends:
 Imports:
     rlang (>= 1.0.4),
     tzdb (>= 0.3.0),
-    vctrs (>= 0.4.1)
+    vctrs (>= 0.5.0)
 Suggests: 
     covr,
     knitr,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # clock (development version)
 
+* vctrs >=0.5.0 is now required (#303).
+
 # clock 0.6.1
 
 * `date_seq()` and the `seq()` methods for the calendar, time point, and

--- a/R/rcrd.R
+++ b/R/rcrd.R
@@ -56,7 +56,7 @@ clock_rcrd_is_nan <- function(x) {
 }
 
 clock_rcrd_is_finite <- function(x) {
-  !vec_equal_na(x)
+  !vec_detect_missing(x)
 }
 
 clock_rcrd_is_infinite <- function(x) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -57,7 +57,7 @@ ones_along <- function(x, na_propagate = FALSE) {
     return(out)
   }
 
-  na <- vec_equal_na(x)
+  na <- vec_detect_missing(x)
   if (any(na)) {
     out[na] <- NA_integer_
   }
@@ -71,7 +71,7 @@ zeros_along <- function(x, na_propagate = FALSE) {
     return(out)
   }
 
-  na <- vec_equal_na(x)
+  na <- vec_detect_missing(x)
   if (any(na)) {
     out[na] <- NA_integer_
   }
@@ -355,7 +355,7 @@ if_else <- function(condition, true, false, na = NULL) {
   out <- vec_assign(out, loc_false, vec_slice(args$false, loc_false))
 
   if (!is_null(na)) {
-    loc_na <- vec_equal_na(condition)
+    loc_na <- vec_detect_missing(condition)
     out <- vec_assign(out, loc_na, vec_slice(args$na, loc_na))
   }
 

--- a/R/weekday.R
+++ b/R/weekday.R
@@ -505,7 +505,7 @@ weekday_is_nan <- function(x) {
 }
 
 weekday_is_finite <- function(x) {
-  !vec_equal_na(x)
+  !vec_detect_missing(x)
 }
 
 weekday_is_infinite <- function(x) {

--- a/tests/testthat/_snaps/calendar.md
+++ b/tests/testthat/_snaps/calendar.md
@@ -220,7 +220,7 @@
     Code
       (expect_error(calendar_count_between(x, x, "year", n = "x")))
     Output
-      <error/vctrs_error_incompatible_type>
+      <error/vctrs_error_cast>
       Error in `calendar_count_between()`:
       ! Can't convert `n` <character> to <integer>.
     Code

--- a/tests/testthat/_snaps/date.md
+++ b/tests/testthat/_snaps/date.md
@@ -184,11 +184,13 @@
 
 # validates integerish `by`
 
-    Can't convert `by` <double> to <integer>.
+    Can't convert from `by` <double> to <integer> due to loss of precision.
+    * Locations: 1
 
 # validates `total_size` early
 
-    Can't convert `total_size` <double> to <integer>.
+    Can't convert from `total_size` <double> to <integer> due to loss of precision.
+    * Locations: 1
 
 ---
 

--- a/tests/testthat/_snaps/naive-time.md
+++ b/tests/testthat/_snaps/naive-time.md
@@ -14,7 +14,7 @@
       Warning:
       Failed to parse 1 string at location 1. Returning `NA` at that location.
     Output
-      <time_point<naive><day>[1]>
+      <clock_naive_time[1]>
       [1] NA
 
 # failure to parse throws a warning
@@ -25,7 +25,7 @@
       Warning:
       Failed to parse 1 string at location 1. Returning `NA` at that location.
     Output
-      <time_point<naive><second>[1]>
+      <clock_naive_time[1]>
       [1] NA
 
 # default format is correct

--- a/tests/testthat/_snaps/posixt.md
+++ b/tests/testthat/_snaps/posixt.md
@@ -292,11 +292,13 @@
 
 # validates integerish `by`
 
-    Can't convert `by` <double> to <integer>.
+    Can't convert from `by` <double> to <integer> due to loss of precision.
+    * Locations: 1
 
 # validates `total_size` early
 
-    Can't convert `total_size` <double> to <integer>.
+    Can't convert from `total_size` <double> to <integer> due to loss of precision.
+    * Locations: 1
 
 ---
 

--- a/tests/testthat/_snaps/sys-time.md
+++ b/tests/testthat/_snaps/sys-time.md
@@ -6,7 +6,7 @@
       Warning:
       Failed to parse 1 string at location 1. Returning `NA` at that location.
     Output
-      <time_point<sys><second>[1]>
+      <clock_sys_time[1]>
       [1] NA
 
 # `precision` must be at least second

--- a/tests/testthat/_snaps/time-point.md
+++ b/tests/testthat/_snaps/time-point.md
@@ -3,7 +3,7 @@
     Code
       x
     Output
-      <time_point<sys><day>[5]>
+      <clock_sys_time[5]>
       [1] "2019-01-01" "2019-02-01" "2019-03-01" "2019-04-01" "2019-05-01"
 
 # can limit with `max`
@@ -11,7 +11,7 @@
     Code
       print(x, max = 2)
     Output
-      <time_point<sys><day>[5]>
+      <clock_sys_time[5]>
       [1] "2019-01-01" "2019-02-01"
       Reached `max` or `getOption('max.print')`. Omitted 3 values.
 
@@ -20,7 +20,7 @@
     Code
       print(x, max = 4)
     Output
-      <time_point<sys><day>[5]>
+      <clock_sys_time[5]>
       [1] "2019-01-01" "2019-02-01" "2019-03-01" "2019-04-01"
       Reached `max` or `getOption('max.print')`. Omitted 1 value.
 
@@ -29,7 +29,7 @@
     Code
       print(x, max = 5)
     Output
-      <time_point<sys><day>[5]>
+      <clock_sys_time[5]>
       [1] "2019-01-01" "2019-02-01" "2019-03-01" "2019-04-01" "2019-05-01"
 
 ---
@@ -37,7 +37,7 @@
     Code
       print(x, max = 6)
     Output
-      <time_point<sys><day>[5]>
+      <clock_sys_time[5]>
       [1] "2019-01-01" "2019-02-01" "2019-03-01" "2019-04-01" "2019-05-01"
 
 # `max` defaults to `getOption('max.print')` but can be overridden
@@ -45,7 +45,7 @@
     Code
       x
     Output
-      <time_point<naive><day>[5]>
+      <clock_naive_time[5]>
       [1] "2019-01-01" "2019-02-01" "2019-03-01"
       Reached `max` or `getOption('max.print')`. Omitted 2 values.
 
@@ -54,7 +54,7 @@
     Code
       print(x, max = 4)
     Output
-      <time_point<naive><day>[5]>
+      <clock_naive_time[5]>
       [1] "2019-01-01" "2019-02-01" "2019-03-01" "2019-04-01"
       Reached `max` or `getOption('max.print')`. Omitted 1 value.
 
@@ -63,7 +63,7 @@
     Code
       print(x, max = 5)
     Output
-      <time_point<naive><day>[5]>
+      <clock_naive_time[5]>
       [1] "2019-01-01" "2019-02-01" "2019-03-01" "2019-04-01" "2019-05-01"
 
 # cannot floor to more precise precision
@@ -72,11 +72,11 @@
 
 # rounding with `origin` requires same clock
 
-    Can't convert `origin` <time_point<sys><day>> to <time_point<naive><day>>.
+    Can't convert `origin` <clock_sys_time> to <clock_naive_time>.
 
 # `origin` can be cast to a more precise `precision`, but not to a less precise one
 
-    Can't convert `origin` <time_point<naive><millisecond>> to <time_point<naive><hour>>.
+    Can't convert `origin` <clock_naive_time> to <clock_naive_time>.
     Can't cast to a less precise precision.
 
 # `origin` must be size 1
@@ -89,11 +89,11 @@
 
 # `origin` can't be Date or POSIXt
 
-    Can't convert `origin` <date> to <time_point<naive><day>>.
+    Can't convert `origin` <date> to <clock_naive_time>.
 
 ---
 
-    Can't convert `origin` <datetime<America/New_York>> to <time_point<naive><day>>.
+    Can't convert `origin` <datetime<America/New_York>> to <clock_naive_time>.
 
 # `target` is recycled to size of `x`
 
@@ -159,9 +159,9 @@
     Code
       (expect_error(time_point_count_between(x, y)))
     Output
-      <error/vctrs_error_incompatible_type>
+      <error/vctrs_error_ptype2>
       Error in `time_point_count_between()`:
-      ! Can't combine `start` <time_point<sys><day>> and `end` <time_point<naive><day>>.
+      ! Can't combine `start` <clock_sys_time> and `end` <clock_naive_time>.
 
 # `n` is validated
 
@@ -187,7 +187,7 @@
     Code
       (expect_error(time_point_count_between(x, x, "day", n = "x")))
     Output
-      <error/vctrs_error_incompatible_type>
+      <error/vctrs_error_cast>
       Error in `time_point_count_between()`:
       ! Can't convert `n` <character> to <integer>.
     Code
@@ -213,11 +213,11 @@
 
 # can't mix clocks in seq()
 
-    Can't convert `to` <time_point<naive><second>> to match type of `from` <time_point<sys><second>>.
+    Can't convert `to` <clock_naive_time> to match type of `from` <clock_sys_time>.
 
 # `to` is always cast to `from`
 
-    Can't convert `to` <time_point<naive><second>> to match type of `from` <time_point<naive><day>>.
+    Can't convert `to` <clock_naive_time> to match type of `from` <clock_naive_time>.
     Can't cast to a less precise precision.
 
 # duration to add to a time-point must have at least week precision (#120)


### PR DESCRIPTION
* Eliminates `devtools::test()` WARNINGs and ERRORs
* `vec_equal_na()` was deprecated in {vctrs} v0.5.0 so use `vec_detect_missing()` instead
* Update all snapshots to match current output
