### PR TITLE
Lazily register `slider_plus()` and `slider_minus()` methods

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,6 +29,7 @@ Suggests:
     magrittr,
     pillar,
     rmarkdown,
+    slider (>= 0.2.2.9000),
     testthat (>= 3.0.0),
     withr
 LinkingTo: 
@@ -44,3 +45,5 @@ Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.3
+Remotes:
+    DavisVaughan/slider#184

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,7 +29,7 @@ Suggests:
     magrittr,
     pillar,
     rmarkdown,
-    slider (>= 0.2.2.9000),
+    slider (>= 0.3.0),
     testthat (>= 3.0.0),
     withr
 LinkingTo: 
@@ -45,5 +45,3 @@ Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.3
-Remotes:
-    DavisVaughan/slider#184

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # clock (development version)
 
+* Duration vectors now work as `.before` and `.after` arguments of
+  `slider::slide_index()` and friends (#306).
+
 * R >=3.5.0 is now required, which is in line with tidyverse standards.
 
 * vctrs >=0.6.1 and rlang >=1.1.0 are now required.

--- a/R/date.R
+++ b/R/date.R
@@ -356,6 +356,18 @@ arith_duration_and_date <- function(op, x, y, ...) {
 
 # ------------------------------------------------------------------------------
 
+# @export - .onLoad()
+slider_plus.Date.clock_duration <- function(x, y) {
+  vec_arith("+", x, y)
+}
+
+# @export - .onLoad()
+slider_minus.Date.clock_duration <- function(x, y) {
+  vec_arith("-", x, y)
+}
+
+# ------------------------------------------------------------------------------
+
 #' Arithmetic: date
 #'
 #' @description

--- a/R/posixt.R
+++ b/R/posixt.R
@@ -491,6 +491,28 @@ arith_duration_and_posixt <- function(op, x, y, ...) {
 
 # ------------------------------------------------------------------------------
 
+# @export - .onLoad()
+slider_plus.POSIXct.clock_duration <- function(x, y) {
+  vec_arith("+", x, y)
+}
+
+# @export - .onLoad()
+slider_plus.POSIXlt.clock_duration <- function(x, y) {
+  vec_arith("+", x, y)
+}
+
+# @export - .onLoad()
+slider_minus.POSIXct.clock_duration <- function(x, y) {
+  vec_arith("-", x, y)
+}
+
+# @export - .onLoad()
+slider_minus.POSIXlt.clock_duration <- function(x, y) {
+  vec_arith("-", x, y)
+}
+
+# ------------------------------------------------------------------------------
+
 #' Arithmetic: date-time
 #'
 #' @description

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -20,6 +20,14 @@
   vctrs::s3_register("pillar::pillar_shaft", "clock_calendar", pillar_shaft.clock_calendar)
   vctrs::s3_register("pillar::pillar_shaft", "clock_time_point", pillar_shaft.clock_time_point)
   vctrs::s3_register("pillar::pillar_shaft", "clock_zoned_time", pillar_shaft.clock_zoned_time)
+
+  vctrs::s3_register("slider::slider_plus", "Date.clock_duration", slider_plus.Date.clock_duration)
+  vctrs::s3_register("slider::slider_plus", "POSIXct.clock_duration", slider_plus.POSIXct.clock_duration)
+  vctrs::s3_register("slider::slider_plus", "POSIXlt.clock_duration", slider_plus.POSIXlt.clock_duration)
+
+  vctrs::s3_register("slider::slider_minus", "Date.clock_duration", slider_minus.Date.clock_duration)
+  vctrs::s3_register("slider::slider_minus", "POSIXct.clock_duration", slider_minus.POSIXct.clock_duration)
+  vctrs::s3_register("slider::slider_minus", "POSIXlt.clock_duration", slider_minus.POSIXlt.clock_duration)
 }
 
 # nocov end

--- a/tests/testthat/_snaps/date.md
+++ b/tests/testthat/_snaps/date.md
@@ -287,3 +287,12 @@
 
     <duration<year>> * <date> is not permitted
 
+# `slide_index()` will error on calendrical arithmetic and invalid dates
+
+    Code
+      slider::slide_index(x, i, identity, .after = after)
+    Condition
+      Error in `stop_clock()`:
+      ! Invalid date found at location 2.
+      i Resolve invalid date issues by specifying the `invalid` argument.
+

--- a/tests/testthat/_snaps/posixt.md
+++ b/tests/testthat/_snaps/posixt.md
@@ -408,3 +408,39 @@
 
     <duration<year>> * <POSIXlt<America/New_York>> is not permitted
 
+# `slide_index()` will error on naive-time based arithmetic and ambiguous times
+
+    Code
+      slider::slide_index(x, i, identity, .after = after)
+    Condition
+      Error in `stop_clock()`:
+      ! Ambiguous time due to daylight saving time at location 1.
+      i Resolve ambiguous time issues by specifying the `ambiguous` argument.
+
+# `slide_index()` will error on naive-time based arithmetic and nonexistent times
+
+    Code
+      slider::slide_index(x, i, identity, .after = after)
+    Condition
+      Error in `stop_clock()`:
+      ! Nonexistent time due to daylight saving time at location 1.
+      i Resolve nonexistent time issues by specifying the `nonexistent` argument.
+
+# `slide_index()` will error on calendrical arithmetic and ambiguous times
+
+    Code
+      slider::slide_index(x, i, identity, .after = after)
+    Condition
+      Error in `stop_clock()`:
+      ! Ambiguous time due to daylight saving time at location 1.
+      i Resolve ambiguous time issues by specifying the `ambiguous` argument.
+
+# `slide_index()` will error on calendrical arithmetic and nonexistent times
+
+    Code
+      slider::slide_index(x, i, identity, .after = after)
+    Condition
+      Error in `stop_clock()`:
+      ! Nonexistent time due to daylight saving time at location 1.
+      i Resolve nonexistent time issues by specifying the `nonexistent` argument.
+

--- a/tests/testthat/test-date.R
+++ b/tests/testthat/test-date.R
@@ -613,7 +613,7 @@ test_that("<duration> op <date>", {
 # slider_plus() / slider_minus()
 
 test_that("`slider_plus()` method is registered", {
-  skip_if_not_installed("slider", minimum_version = "0.2.2.9000")
+  skip_if_not_installed("slider", minimum_version = "0.3.0")
 
   x <- date_build(2019, 1, 1:2)
 
@@ -631,7 +631,7 @@ test_that("`slider_plus()` method is registered", {
 })
 
 test_that("`slider_minus()` method is registered", {
-  skip_if_not_installed("slider", minimum_version = "0.2.2.9000")
+  skip_if_not_installed("slider", minimum_version = "0.3.0")
 
   x <- date_build(2019, 1, 1:2)
 
@@ -649,7 +649,7 @@ test_that("`slider_minus()` method is registered", {
 })
 
 test_that("`slide_index()` works with dates and durations", {
-  skip_if_not_installed("slider", minimum_version = "0.2.2.9000")
+  skip_if_not_installed("slider", minimum_version = "0.3.0")
 
   i <- date_build(2019, 1, 1:4)
   x <- seq_along(i)
@@ -669,7 +669,7 @@ test_that("`slide_index()` works with dates and durations", {
 })
 
 test_that("`slide_index()` will error on calendrical arithmetic and invalid dates", {
-  skip_if_not_installed("slider", minimum_version = "0.2.2.9000")
+  skip_if_not_installed("slider", minimum_version = "0.3.0")
 
   i <- date_build(2019, 1, 28:31)
   x <- seq_along(i)

--- a/tests/testthat/test-date.R
+++ b/tests/testthat/test-date.R
@@ -608,3 +608,75 @@ test_that("<duration> op <date>", {
   expect_snapshot_error(vec_arith("+", duration_hours(1), new_date(0)))
   expect_snapshot_error(vec_arith("*", duration_years(1), new_date(0)))
 })
+
+# ------------------------------------------------------------------------------
+# slider_plus() / slider_minus()
+
+test_that("`slider_plus()` method is registered", {
+  skip_if_not_installed("slider", minimum_version = "0.2.2.9000")
+
+  x <- date_build(2019, 1, 1:2)
+
+  y <- duration_days(2)
+  expect_identical(
+    slider::slider_plus(x, y),
+    date_build(2019, 1, 3:4)
+  )
+
+  y <- duration_years(1)
+  expect_identical(
+    slider::slider_plus(x, y),
+    date_build(2020, 1, 1:2)
+  )
+})
+
+test_that("`slider_minus()` method is registered", {
+  skip_if_not_installed("slider", minimum_version = "0.2.2.9000")
+
+  x <- date_build(2019, 1, 1:2)
+
+  y <- duration_days(2)
+  expect_identical(
+    slider::slider_minus(x, y),
+    date_build(2018, 12, 30:31)
+  )
+
+  y <- duration_years(1)
+  expect_identical(
+    slider::slider_minus(x, y),
+    date_build(2018, 1, 1:2)
+  )
+})
+
+test_that("`slide_index()` works with dates and durations", {
+  skip_if_not_installed("slider", minimum_version = "0.2.2.9000")
+
+  i <- date_build(2019, 1, 1:4)
+  x <- seq_along(i)
+
+  before <- duration_days(1)
+  after <- duration_days(2)
+
+  expect_identical(
+    slider::slide_index(x, i, identity, .before = before, .after = after),
+    list(
+      1:3,
+      1:4,
+      2:4,
+      3:4
+    )
+  )
+})
+
+test_that("`slide_index()` will error on calendrical arithmetic and invalid dates", {
+  skip_if_not_installed("slider", minimum_version = "0.2.2.9000")
+
+  i <- date_build(2019, 1, 28:31)
+  x <- seq_along(i)
+
+  after <- duration_months(1)
+
+  expect_snapshot(error = TRUE, {
+    slider::slide_index(x, i, identity, .after = after)
+  })
+})

--- a/tests/testthat/test-posixt.R
+++ b/tests/testthat/test-posixt.R
@@ -1002,7 +1002,7 @@ test_that("<duration> op <posixt>", {
 # slider_plus() / slider_minus()
 
 test_that("`slider_plus()` method is registered", {
-  skip_if_not_installed("slider", minimum_version = "0.2.2.9000")
+  skip_if_not_installed("slider", minimum_version = "0.3.0")
 
   zone <- "America/New_York"
 
@@ -1030,7 +1030,7 @@ test_that("`slider_plus()` method is registered", {
 })
 
 test_that("`slider_minus()` method is registered", {
-  skip_if_not_installed("slider", minimum_version = "0.2.2.9000")
+  skip_if_not_installed("slider", minimum_version = "0.3.0")
 
   zone <- "America/New_York"
 
@@ -1058,7 +1058,7 @@ test_that("`slider_minus()` method is registered", {
 })
 
 test_that("`slide_index()` works with date-times and durations", {
-  skip_if_not_installed("slider", minimum_version = "0.2.2.9000")
+  skip_if_not_installed("slider", minimum_version = "0.3.0")
 
   zone <- "America/New_York"
 
@@ -1088,7 +1088,7 @@ test_that("`slide_index()` works with date-times and durations", {
 })
 
 test_that("`slide_index()` with date-times and sys-time based arithmetic is sensible around ambiguous times", {
-  skip_if_not_installed("slider", minimum_version = "0.2.2.9000")
+  skip_if_not_installed("slider", minimum_version = "0.3.0")
 
   zone <- "America/New_York"
 
@@ -1114,7 +1114,7 @@ test_that("`slide_index()` with date-times and sys-time based arithmetic is sens
 })
 
 test_that("`slide_index()` with date-times and sys-time based arithmetic is sensible around nonexistent times", {
-  skip_if_not_installed("slider", minimum_version = "0.2.2.9000")
+  skip_if_not_installed("slider", minimum_version = "0.3.0")
 
   zone <- "America/New_York"
 
@@ -1138,7 +1138,7 @@ test_that("`slide_index()` with date-times and sys-time based arithmetic is sens
 })
 
 test_that("`slide_index()` will error on naive-time based arithmetic and ambiguous times", {
-  skip_if_not_installed("slider", minimum_version = "0.2.2.9000")
+  skip_if_not_installed("slider", minimum_version = "0.3.0")
 
   zone <- "America/New_York"
 
@@ -1154,7 +1154,7 @@ test_that("`slide_index()` will error on naive-time based arithmetic and ambiguo
 })
 
 test_that("`slide_index()` will error on naive-time based arithmetic and nonexistent times", {
-  skip_if_not_installed("slider", minimum_version = "0.2.2.9000")
+  skip_if_not_installed("slider", minimum_version = "0.3.0")
 
   zone <- "America/New_York"
 
@@ -1170,7 +1170,7 @@ test_that("`slide_index()` will error on naive-time based arithmetic and nonexis
 })
 
 test_that("`slide_index()` will error on calendrical arithmetic and ambiguous times", {
-  skip_if_not_installed("slider", minimum_version = "0.2.2.9000")
+  skip_if_not_installed("slider", minimum_version = "0.3.0")
 
   zone <- "America/New_York"
 
@@ -1186,7 +1186,7 @@ test_that("`slide_index()` will error on calendrical arithmetic and ambiguous ti
 })
 
 test_that("`slide_index()` will error on calendrical arithmetic and nonexistent times", {
-  skip_if_not_installed("slider", minimum_version = "0.2.2.9000")
+  skip_if_not_installed("slider", minimum_version = "0.3.0")
 
   zone <- "America/New_York"
 


### PR DESCRIPTION
Joint PR with https://github.com/DavisVaughan/slider/pull/184

- [x] Bump required slider version in DESCRIPTION to CRAN version
- [x] Bump required slider version in skip_if_not_installed() to CRAN version
- [x] Remove slider Remote

``` r
library(clock)
library(slider)

i <- date_build(2019, 1, c(1, 3, 4, 5, 7, 8))

slide_index(i, i, identity, .before = duration_days(2))
#> [[1]]
#> [1] "2019-01-01"
#> 
#> [[2]]
#> [1] "2019-01-01" "2019-01-03"
#> 
#> [[3]]
#> [1] "2019-01-03" "2019-01-04"
#> 
#> [[4]]
#> [1] "2019-01-03" "2019-01-04" "2019-01-05"
#> 
#> [[5]]
#> [1] "2019-01-05" "2019-01-07"
#> 
#> [[6]]
#> [1] "2019-01-07" "2019-01-08"
```

<sup>Created on 2022-11-10 with [reprex v2.0.2.9000](https://reprex.tidyverse.org)</sup>