### PR TITLE
Skip problematic test on 32-bit architectures

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # clock (development version)
 
+* Skipped a test on 32-bit architectures to work around a bug in base R (#312).
+
 * Fixed `vec_ptype_full()` and `vec_ptype_abbr()` methods for sys-time and
   naive-time objects (#302).
 

--- a/tests/testthat/test-posixt.R
+++ b/tests/testthat/test-posixt.R
@@ -131,7 +131,23 @@ test_that("converting to weekday retains names", {
 # ------------------------------------------------------------------------------
 # date_group()
 
-test_that("can group by year/month/day/hour/minute/second", {
+test_that("can group by year (#312)", {
+  # Skip on 32-bit machines
+  # https://github.com/r-lib/clock/issues/312#issuecomment-1507528450
+  skip_if(
+    condition = .Machine$sizeof.pointer < 8L,
+    message = "Likely an integer overflow/underflow bug in base R here"
+  )
+
+  # Using year 0 as the starting point
+  x <- as.POSIXct(c("0000-01-05", "0001-02-10", "0002-03-12", "0003-01-15", "0004-12-10"), "America/New_York")
+  expect <- set_month(set_day(x, 1), 1)
+
+  expect_identical(date_group(x, "year"), expect)
+  expect_identical(date_group(x, "year", n = 3), expect[c(1, 1, 1, 4, 4)])
+})
+
+test_that("can group by month/day/hour/minute/second", {
   x <- as.POSIXct("2019-01-01", "America/New_York")
   x <- add_days(x, 0:3)
 
@@ -144,17 +160,10 @@ test_that("can group by year/month/day/hour/minute/second", {
   expect_identical(date_group(y, "month"), expect)
   expect_identical(date_group(y, "month", n = 2), expect[c(1, 1, 3)])
 
-  # Using year 0 as the starting point
-  z <- as.POSIXct(c("0000-01-05", "0001-02-10", "0002-03-12", "0003-01-15", "0004-12-10"), "America/New_York")
-  expect <- set_month(set_day(z, 1), 1)
+  z <- as.POSIXct("2019-01-01", "America/New_York")
+  z <- add_hours(z, c(0, 1, 2, 4, 5))
 
-  expect_identical(date_group(z, "year"), expect)
-  expect_identical(date_group(z, "year", n = 3), expect[c(1, 1, 1, 4, 4)])
-
-  w <- as.POSIXct("2019-01-01", "America/New_York")
-  w <- add_hours(w, c(0, 1, 2, 4, 5))
-
-  expect_identical(date_group(w, "hour", n = 2), w[c(1, 1, 3, 4, 4)])
+  expect_identical(date_group(z, "hour", n = 2), z[c(1, 1, 3, 4, 4)])
 })
 
 test_that("can handle nonexistent times resulting from grouping", {


### PR DESCRIPTION
Closes #312 

In particular see https://github.com/r-lib/clock/issues/312#issuecomment-1507528450