### PR TITLE
Use a template free shim around `quarterly.h` classes

### DIFF
--- a/src/quarterly-shim.h
+++ b/src/quarterly-shim.h
@@ -1,0 +1,677 @@
+#ifndef CLOCK_QUARTERLY_SHIM_H
+#define CLOCK_QUARTERLY_SHIM_H
+
+/*
+ * This file contains a minimal shim around the classes in `quarterly.h` that
+ * exposes those classes in a template free way. The templating is necessary
+ * in `quarterly.h` to correctly define the type, since the quarter start month
+ * is a part of the type itself, but we can gloss over some of those details
+ * for use in `quarterly-year-quarter-day.h`. Encapsulating the templates here
+ * reduces the compilation time of clock significantly (around 3x, on an Intel
+ * Mac the compilation time dropped from 70s to 25s).
+ */
+
+#include <tzdb/date.h>
+#include "quarterly.h"
+
+namespace rclock {
+namespace rquarterly {
+namespace quarterly_shim {
+
+class year;
+
+class year_quarternum;
+
+class year_quarternum_quarterday;
+class year_quarternum_quarterday_last;
+
+// date composition operators
+
+CONSTCD11 year_quarternum operator/(const year& y, const quarterly::quarternum& qn) NOEXCEPT;
+CONSTCD11 year_quarternum operator/(const year& y, int                          qn) NOEXCEPT;
+
+CONSTCD11 year_quarternum_quarterday operator/(const year_quarternum& yqn, const quarterly::quarterday& qd) NOEXCEPT;
+CONSTCD11 year_quarternum_quarterday operator/(const year_quarternum& yqn, int                          qd) NOEXCEPT;
+
+CONSTCD11 year_quarternum_quarterday_last operator/(const year_quarternum& yqn, quarterly::last_spec) NOEXCEPT;
+
+// year
+
+class year
+{
+  short y_;
+  quarterly::start s_;
+
+public:
+  year() = default;
+  explicit CONSTCD11 year(int y, quarterly::start s) NOEXCEPT;
+
+  CONSTCD11 quarterly::start start() const NOEXCEPT;
+
+  CONSTCD11 explicit operator int() const NOEXCEPT;
+  CONSTCD11 bool ok() const NOEXCEPT;
+};
+
+CONSTCD11 year operator+(const year& x, const quarterly::years& y) NOEXCEPT;
+
+CONSTCD11 quarterly::years operator-(const year& x, const year& y) NOEXCEPT;
+
+// year_quarternum
+
+class year_quarternum
+{
+  quarterly_shim::year y_;
+  quarterly::quarternum qn_;
+
+public:
+  year_quarternum() = default;
+  CONSTCD11 year_quarternum(const quarterly_shim::year& y,
+                            const quarterly::quarternum& qn) NOEXCEPT;
+
+  CONSTCD11 quarterly_shim::year year() const NOEXCEPT;
+  CONSTCD11 quarterly::quarternum quarternum() const NOEXCEPT;
+
+  CONSTCD11 bool ok() const NOEXCEPT;
+};
+
+CONSTCD14 year_quarternum operator+(const year_quarternum& yqn, const quarterly::quarters& dq) NOEXCEPT;
+
+CONSTCD11 quarterly::quarters operator-(const year_quarternum& x, const year_quarternum& y) NOEXCEPT;
+
+// year_quarternum_quarterday
+
+class year_quarternum_quarterday
+{
+  quarterly_shim::year y_;
+  quarterly::quarternum qn_;
+  quarterly::quarterday qd_;
+
+public:
+  year_quarternum_quarterday() = default;
+  CONSTCD11 year_quarternum_quarterday(const quarterly_shim::year& y,
+                                       const quarterly::quarternum& qn,
+                                       const quarterly::quarterday& qd) NOEXCEPT;
+  CONSTCD11 year_quarternum_quarterday(const quarterly_shim::year_quarternum& yqn,
+                                       const quarterly::quarterday& qd) NOEXCEPT;
+  CONSTCD14 year_quarternum_quarterday(const year_quarternum_quarterday_last& yqnqdl) NOEXCEPT;
+  CONSTCD14 year_quarternum_quarterday(const date::sys_days& dp, quarterly::start s) NOEXCEPT;
+  CONSTCD14 year_quarternum_quarterday(const date::local_days& dp, quarterly::start s) NOEXCEPT;
+
+  CONSTCD11 quarterly_shim::year year() const NOEXCEPT;
+  CONSTCD11 quarterly::quarternum quarternum() const NOEXCEPT;
+  CONSTCD11 quarterly::quarterday quarterday() const NOEXCEPT;
+
+  CONSTCD14 operator date::sys_days() const NOEXCEPT;
+  CONSTCD14 explicit operator date::local_days() const NOEXCEPT;
+  CONSTCD14 bool ok() const NOEXCEPT;
+
+private:
+  CONSTCD14 year_quarternum_quarterday from_sys_days(const date::sys_days& dp, quarterly::start s) NOEXCEPT;
+  CONSTCD14 year_quarternum_quarterday from_local_days(const date::local_days& dp, quarterly::start s) NOEXCEPT;
+};
+
+// year_quarternum_quarterday_last
+
+class year_quarternum_quarterday_last
+{
+  quarterly_shim::year y_;
+  quarterly::quarternum qn_;
+
+public:
+  year_quarternum_quarterday_last() = default;
+  CONSTCD11 year_quarternum_quarterday_last(const quarterly_shim::year& y,
+                                            const quarterly::quarternum& qn) NOEXCEPT;
+  CONSTCD11 year_quarternum_quarterday_last(const quarterly_shim::year_quarternum& yqn) NOEXCEPT;
+
+  CONSTCD11 quarterly_shim::year year() const NOEXCEPT;
+  CONSTCD11 quarterly::quarternum quarternum() const NOEXCEPT;
+  CONSTCD14 quarterly::quarterday quarterday() const NOEXCEPT;
+};
+
+//----------------+
+// Implementation |
+//----------------+
+
+namespace detail {
+
+template <quarterly::start S>
+CONSTCD14
+inline
+quarterly::year<S>
+to_quarterly(const quarterly_shim::year& y) NOEXCEPT {
+  return quarterly::year<S>(static_cast<int>(y));
+}
+
+template <quarterly::start S>
+CONSTCD14
+inline
+quarterly::year_quarternum<S>
+to_quarterly(const quarterly_shim::year_quarternum& yqn) NOEXCEPT {
+  return quarterly::year_quarternum<S>(
+    to_quarterly<S>(yqn.year()),
+    yqn.quarternum()
+  );
+}
+
+template <quarterly::start S>
+CONSTCD14
+inline
+quarterly::year_quarternum_quarterday<S>
+to_quarterly(const quarterly_shim::year_quarternum_quarterday& yqnqd) NOEXCEPT {
+  return quarterly::year_quarternum_quarterday<S>(
+    to_quarterly<S>(yqnqd.year()),
+    yqnqd.quarternum(),
+    yqnqd.quarterday()
+  );
+}
+
+template <quarterly::start S>
+CONSTCD14
+inline
+quarterly::year_quarternum_quarterday_last<S>
+to_quarterly(const quarterly_shim::year_quarternum_quarterday_last& yqnqdl) NOEXCEPT {
+  return quarterly::year_quarternum_quarterday_last<S>(
+    to_quarterly<S>(yqnqdl.year()),
+    yqnqdl.quarternum()
+  );
+}
+
+template <quarterly::start S>
+CONSTCD14
+inline
+quarterly_shim::year
+from_quarterly(const quarterly::year<S>& y) NOEXCEPT {
+  return quarterly_shim::year(static_cast<int>(y), y.start());
+}
+
+template <quarterly::start S>
+CONSTCD14
+inline
+quarterly_shim::year_quarternum
+from_quarterly(const quarterly::year_quarternum<S>& yqn) NOEXCEPT {
+  return quarterly_shim::year_quarternum(
+    from_quarterly(yqn.year()),
+    yqn.quarternum()
+  );
+}
+
+template <quarterly::start S>
+CONSTCD14
+inline
+quarterly_shim::year_quarternum_quarterday
+from_quarterly(const quarterly::year_quarternum_quarterday<S>& yqnqd) NOEXCEPT {
+  return quarterly_shim::year_quarternum_quarterday(
+    from_quarterly(yqnqd.year()),
+    yqnqd.quarternum(),
+    yqnqd.quarterday()
+  );
+}
+
+} // namespace detail
+
+// year
+
+CONSTCD11
+inline
+year::year(int y, quarterly::start s) NOEXCEPT
+  : y_(static_cast<decltype(y_)>(y)),
+    s_(s)
+  {}
+
+CONSTCD11
+inline
+year::operator int() const NOEXCEPT
+{
+  return y_;
+}
+
+CONSTCD11
+inline
+bool
+year::ok() const NOEXCEPT
+{
+  using start = quarterly::start;
+  using detail::to_quarterly;
+
+  switch (s_) {
+  case start::january: return to_quarterly<start::january>(*this).ok();
+  case start::february: return to_quarterly<start::february>(*this).ok();
+  case start::march: return to_quarterly<start::march>(*this).ok();
+  case start::april: return to_quarterly<start::april>(*this).ok();
+  case start::may: return to_quarterly<start::may>(*this).ok();
+  case start::june: return to_quarterly<start::june>(*this).ok();
+  case start::july: return to_quarterly<start::july>(*this).ok();
+  case start::august: return to_quarterly<start::august>(*this).ok();
+  case start::september: return to_quarterly<start::september>(*this).ok();
+  case start::october: return to_quarterly<start::october>(*this).ok();
+  case start::november: return to_quarterly<start::november>(*this).ok();
+  case start::december: return to_quarterly<start::december>(*this).ok();
+  }
+}
+
+CONSTCD11
+inline
+quarterly::start
+year::start() const NOEXCEPT
+{
+  return s_;
+}
+
+CONSTCD11
+inline
+year
+operator+(const year& x, const quarterly::years& y) NOEXCEPT
+{
+  using start = quarterly::start;
+  using detail::from_quarterly;
+  using detail::to_quarterly;
+
+  switch (x.start()) {
+  case start::january: return from_quarterly(to_quarterly<start::january>(x) + y);
+  case start::february: return from_quarterly(to_quarterly<start::february>(x) + y);
+  case start::march: return from_quarterly(to_quarterly<start::march>(x) + y);
+  case start::april: return from_quarterly(to_quarterly<start::april>(x) + y);
+  case start::may: return from_quarterly(to_quarterly<start::may>(x) + y);
+  case start::june: return from_quarterly(to_quarterly<start::june>(x) + y);
+  case start::july: return from_quarterly(to_quarterly<start::july>(x) + y);
+  case start::august: return from_quarterly(to_quarterly<start::august>(x) + y);
+  case start::september: return from_quarterly(to_quarterly<start::september>(x) + y);
+  case start::october: return from_quarterly(to_quarterly<start::october>(x) + y);
+  case start::november: return from_quarterly(to_quarterly<start::november>(x) + y);
+  case start::december: return from_quarterly(to_quarterly<start::december>(x) + y);
+  }
+}
+
+CONSTCD11
+inline
+quarterly::years
+operator-(const year& x, const year& y) NOEXCEPT
+{
+  using start = quarterly::start;
+  using detail::to_quarterly;
+
+  // Assumes `x.start()` and `y.start()` are the same, verified by caller
+  switch (x.start()) {
+  case start::january: return to_quarterly<start::january>(x) - to_quarterly<start::january>(y);
+  case start::february: return to_quarterly<start::february>(x) - to_quarterly<start::february>(y);
+  case start::march: return to_quarterly<start::march>(x) - to_quarterly<start::march>(y);
+  case start::april: return to_quarterly<start::april>(x) - to_quarterly<start::april>(y);
+  case start::may: return to_quarterly<start::may>(x) - to_quarterly<start::may>(y);
+  case start::june: return to_quarterly<start::june>(x) - to_quarterly<start::june>(y);
+  case start::july: return to_quarterly<start::july>(x) - to_quarterly<start::july>(y);
+  case start::august: return to_quarterly<start::august>(x) - to_quarterly<start::august>(y);
+  case start::september: return to_quarterly<start::september>(x) - to_quarterly<start::september>(y);
+  case start::october: return to_quarterly<start::october>(x) - to_quarterly<start::october>(y);
+  case start::november: return to_quarterly<start::november>(x) - to_quarterly<start::november>(y);
+  case start::december: return to_quarterly<start::december>(x) - to_quarterly<start::december>(y);
+  }
+}
+
+// year_quarternum
+
+CONSTCD11
+inline
+year_quarternum::year_quarternum(const quarterly_shim::year& y,
+                                 const quarterly::quarternum& qn) NOEXCEPT
+  : y_(y)
+  , qn_(qn)
+  {}
+
+CONSTCD11
+inline
+bool
+year_quarternum::ok() const NOEXCEPT
+{
+  using start = quarterly::start;
+  using detail::to_quarterly;
+
+  switch (y_.start()) {
+  case start::january: return to_quarterly<start::january>(*this).ok();
+  case start::february: return to_quarterly<start::february>(*this).ok();
+  case start::march: return to_quarterly<start::march>(*this).ok();
+  case start::april: return to_quarterly<start::april>(*this).ok();
+  case start::may: return to_quarterly<start::may>(*this).ok();
+  case start::june: return to_quarterly<start::june>(*this).ok();
+  case start::july: return to_quarterly<start::july>(*this).ok();
+  case start::august: return to_quarterly<start::august>(*this).ok();
+  case start::september: return to_quarterly<start::september>(*this).ok();
+  case start::october: return to_quarterly<start::october>(*this).ok();
+  case start::november: return to_quarterly<start::november>(*this).ok();
+  case start::december: return to_quarterly<start::december>(*this).ok();
+  }
+}
+
+CONSTCD11
+inline
+quarterly_shim::year
+year_quarternum::year() const NOEXCEPT
+{
+  return y_;
+}
+
+CONSTCD11
+inline
+quarterly::quarternum
+year_quarternum::quarternum() const NOEXCEPT
+{
+  return qn_;
+}
+
+CONSTCD14
+inline
+year_quarternum
+operator+(const year_quarternum& yqn, const quarterly::quarters& dq) NOEXCEPT
+{
+  using start = quarterly::start;
+  using detail::from_quarterly;
+  using detail::to_quarterly;
+
+  switch (yqn.year().start()) {
+  case start::january: return from_quarterly(to_quarterly<start::january>(yqn) + dq);
+  case start::february: return from_quarterly(to_quarterly<start::february>(yqn) + dq);
+  case start::march: return from_quarterly(to_quarterly<start::march>(yqn) + dq);
+  case start::april: return from_quarterly(to_quarterly<start::april>(yqn) + dq);
+  case start::may: return from_quarterly(to_quarterly<start::may>(yqn) + dq);
+  case start::june: return from_quarterly(to_quarterly<start::june>(yqn) + dq);
+  case start::july: return from_quarterly(to_quarterly<start::july>(yqn) + dq);
+  case start::august: return from_quarterly(to_quarterly<start::august>(yqn) + dq);
+  case start::september: return from_quarterly(to_quarterly<start::september>(yqn) + dq);
+  case start::october: return from_quarterly(to_quarterly<start::october>(yqn) + dq);
+  case start::november: return from_quarterly(to_quarterly<start::november>(yqn) + dq);
+  case start::december: return from_quarterly(to_quarterly<start::december>(yqn) + dq);
+  }
+}
+
+CONSTCD11
+inline
+quarterly::quarters
+operator-(const year_quarternum& x, const year_quarternum& y) NOEXCEPT
+{
+  using start = quarterly::start;
+  using detail::to_quarterly;
+
+  // Assumes `x.year().start()` and `y.year().start()` are the same, verified by caller
+  switch (x.year().start()) {
+  case start::january: return to_quarterly<start::january>(x) - to_quarterly<start::january>(y);
+  case start::february: return to_quarterly<start::february>(x) - to_quarterly<start::february>(y);
+  case start::march: return to_quarterly<start::march>(x) - to_quarterly<start::march>(y);
+  case start::april: return to_quarterly<start::april>(x) - to_quarterly<start::april>(y);
+  case start::may: return to_quarterly<start::may>(x) - to_quarterly<start::may>(y);
+  case start::june: return to_quarterly<start::june>(x) - to_quarterly<start::june>(y);
+  case start::july: return to_quarterly<start::july>(x) - to_quarterly<start::july>(y);
+  case start::august: return to_quarterly<start::august>(x) - to_quarterly<start::august>(y);
+  case start::september: return to_quarterly<start::september>(x) - to_quarterly<start::september>(y);
+  case start::october: return to_quarterly<start::october>(x) - to_quarterly<start::october>(y);
+  case start::november: return to_quarterly<start::november>(x) - to_quarterly<start::november>(y);
+  case start::december: return to_quarterly<start::december>(x) - to_quarterly<start::december>(y);
+  }
+}
+
+// year_quarternum_quarterday
+
+CONSTCD11
+inline
+year_quarternum_quarterday::year_quarternum_quarterday(const quarterly_shim::year& y,
+                                                       const quarterly::quarternum& qn,
+                                                       const quarterly::quarterday& qd) NOEXCEPT
+  : y_(y)
+  , qn_(qn)
+  , qd_(qd)
+  {}
+
+CONSTCD11
+inline
+year_quarternum_quarterday::year_quarternum_quarterday(const quarterly_shim::year_quarternum& yqn,
+                                                       const quarterly::quarterday& qd) NOEXCEPT
+  : y_(yqn.year())
+  , qn_(yqn.quarternum())
+  , qd_(qd)
+  {}
+
+CONSTCD14
+inline
+year_quarternum_quarterday::year_quarternum_quarterday(const year_quarternum_quarterday_last& yqnqdl) NOEXCEPT
+  : y_(yqnqdl.year())
+  , qn_(yqnqdl.quarternum())
+  , qd_(yqnqdl.quarterday())
+  {}
+
+CONSTCD14
+inline
+year_quarternum_quarterday::year_quarternum_quarterday(const date::sys_days& dp, quarterly::start s) NOEXCEPT
+  : year_quarternum_quarterday(from_sys_days(dp, s))
+  {}
+
+CONSTCD14
+inline
+year_quarternum_quarterday::year_quarternum_quarterday(const date::local_days& dp, quarterly::start s) NOEXCEPT
+  : year_quarternum_quarterday(from_local_days(dp, s))
+  {}
+
+CONSTCD14
+inline
+year_quarternum_quarterday
+year_quarternum_quarterday::from_sys_days(const date::sys_days& dp, quarterly::start s) NOEXCEPT {
+  using start = quarterly::start;
+  using detail::from_quarterly;
+
+  switch (s) {
+  case start::january: return from_quarterly(quarterly::year_quarternum_quarterday<start::january>(dp));
+  case start::february: return from_quarterly(quarterly::year_quarternum_quarterday<start::february>(dp));
+  case start::march: return from_quarterly(quarterly::year_quarternum_quarterday<start::march>(dp));
+  case start::april: return from_quarterly(quarterly::year_quarternum_quarterday<start::april>(dp));
+  case start::may: return from_quarterly(quarterly::year_quarternum_quarterday<start::may>(dp));
+  case start::june: return from_quarterly(quarterly::year_quarternum_quarterday<start::june>(dp));
+  case start::july: return from_quarterly(quarterly::year_quarternum_quarterday<start::july>(dp));
+  case start::august: return from_quarterly(quarterly::year_quarternum_quarterday<start::august>(dp));
+  case start::september: return from_quarterly(quarterly::year_quarternum_quarterday<start::september>(dp));
+  case start::october: return from_quarterly(quarterly::year_quarternum_quarterday<start::october>(dp));
+  case start::november: return from_quarterly(quarterly::year_quarternum_quarterday<start::november>(dp));
+  case start::december: return from_quarterly(quarterly::year_quarternum_quarterday<start::december>(dp));
+  }
+}
+
+CONSTCD14
+inline
+year_quarternum_quarterday
+year_quarternum_quarterday::from_local_days(const date::local_days& dp, quarterly::start s) NOEXCEPT {
+  return from_sys_days(date::sys_days(dp.time_since_epoch()), s);
+}
+
+CONSTCD11
+inline
+quarterly_shim::year
+year_quarternum_quarterday::year() const NOEXCEPT
+{
+  return y_;
+}
+
+CONSTCD11
+inline
+quarterly::quarternum
+year_quarternum_quarterday::quarternum() const NOEXCEPT
+{
+  return qn_;
+}
+
+CONSTCD11
+inline
+quarterly::quarterday
+year_quarternum_quarterday::quarterday() const NOEXCEPT
+{
+  return qd_;
+}
+
+CONSTCD14
+inline
+year_quarternum_quarterday::operator date::sys_days() const NOEXCEPT
+{
+  using start = quarterly::start;
+  using detail::to_quarterly;
+
+  switch (y_.start()) {
+  case start::january: return to_quarterly<start::january>(*this);
+  case start::february: return to_quarterly<start::february>(*this);
+  case start::march: return to_quarterly<start::march>(*this);
+  case start::april: return to_quarterly<start::april>(*this);
+  case start::may: return to_quarterly<start::may>(*this);
+  case start::june: return to_quarterly<start::june>(*this);
+  case start::july: return to_quarterly<start::july>(*this);
+  case start::august: return to_quarterly<start::august>(*this);
+  case start::september: return to_quarterly<start::september>(*this);
+  case start::october: return to_quarterly<start::october>(*this);
+  case start::november: return to_quarterly<start::november>(*this);
+  case start::december: return to_quarterly<start::december>(*this);
+  }
+}
+
+CONSTCD14
+inline
+year_quarternum_quarterday::operator date::local_days() const NOEXCEPT
+{
+  using start = quarterly::start;
+  using detail::to_quarterly;
+
+  switch (y_.start()) {
+  case start::january: return date::local_days(to_quarterly<start::january>(*this));
+  case start::february: return date::local_days(to_quarterly<start::february>(*this));
+  case start::march: return date::local_days(to_quarterly<start::march>(*this));
+  case start::april: return date::local_days(to_quarterly<start::april>(*this));
+  case start::may: return date::local_days(to_quarterly<start::may>(*this));
+  case start::june: return date::local_days(to_quarterly<start::june>(*this));
+  case start::july: return date::local_days(to_quarterly<start::july>(*this));
+  case start::august: return date::local_days(to_quarterly<start::august>(*this));
+  case start::september: return date::local_days(to_quarterly<start::september>(*this));
+  case start::october: return date::local_days(to_quarterly<start::october>(*this));
+  case start::november: return date::local_days(to_quarterly<start::november>(*this));
+  case start::december: return date::local_days(to_quarterly<start::december>(*this));
+  }
+}
+
+CONSTCD14
+inline
+bool
+year_quarternum_quarterday::ok() const NOEXCEPT
+{
+  using start = quarterly::start;
+  using detail::to_quarterly;
+
+  switch (y_.start()) {
+  case start::january: return to_quarterly<start::january>(*this).ok();
+  case start::february: return to_quarterly<start::february>(*this).ok();
+  case start::march: return to_quarterly<start::march>(*this).ok();
+  case start::april: return to_quarterly<start::april>(*this).ok();
+  case start::may: return to_quarterly<start::may>(*this).ok();
+  case start::june: return to_quarterly<start::june>(*this).ok();
+  case start::july: return to_quarterly<start::july>(*this).ok();
+  case start::august: return to_quarterly<start::august>(*this).ok();
+  case start::september: return to_quarterly<start::september>(*this).ok();
+  case start::october: return to_quarterly<start::october>(*this).ok();
+  case start::november: return to_quarterly<start::november>(*this).ok();
+  case start::december: return to_quarterly<start::december>(*this).ok();
+  }
+}
+
+// year_quarternum_quarterday_last
+
+CONSTCD11
+inline
+year_quarternum_quarterday_last::year_quarternum_quarterday_last(const quarterly_shim::year& y,
+                                                                 const quarterly::quarternum& qn) NOEXCEPT
+  : y_(y)
+  , qn_(qn)
+  {}
+
+CONSTCD11
+inline
+year_quarternum_quarterday_last::year_quarternum_quarterday_last(const quarterly_shim::year_quarternum& yqn) NOEXCEPT
+  : y_(yqn.year())
+  , qn_(yqn.quarternum())
+  {}
+
+CONSTCD11
+inline
+quarterly_shim::year
+year_quarternum_quarterday_last::year() const NOEXCEPT
+{
+  return y_;
+}
+
+CONSTCD11
+inline
+quarterly::quarternum
+year_quarternum_quarterday_last::quarternum() const NOEXCEPT
+{
+  return qn_;
+}
+
+CONSTCD14
+inline
+quarterly::quarterday
+year_quarternum_quarterday_last::quarterday() const NOEXCEPT
+{
+  using start = quarterly::start;
+  using detail::to_quarterly;
+
+  switch (y_.start()) {
+  case start::january: return to_quarterly<start::january>(*this).quarterday();
+  case start::february: return to_quarterly<start::february>(*this).quarterday();
+  case start::march: return to_quarterly<start::march>(*this).quarterday();
+  case start::april: return to_quarterly<start::april>(*this).quarterday();
+  case start::may: return to_quarterly<start::may>(*this).quarterday();
+  case start::june: return to_quarterly<start::june>(*this).quarterday();
+  case start::july: return to_quarterly<start::july>(*this).quarterday();
+  case start::august: return to_quarterly<start::august>(*this).quarterday();
+  case start::september: return to_quarterly<start::september>(*this).quarterday();
+  case start::october: return to_quarterly<start::october>(*this).quarterday();
+  case start::november: return to_quarterly<start::november>(*this).quarterday();
+  case start::december: return to_quarterly<start::december>(*this).quarterday();
+  }
+}
+
+// year_quarternum from operator/()
+
+CONSTCD11
+inline
+year_quarternum
+operator/(const year& y, const quarterly::quarternum& qn) NOEXCEPT {
+  return {y, qn};
+}
+
+CONSTCD11
+inline
+year_quarternum
+operator/(const year& y, int qn) NOEXCEPT {
+  return y / quarterly::quarternum(static_cast<unsigned>(qn));
+}
+
+// year_quarternum_quarterday from operator/()
+
+CONSTCD11
+inline
+year_quarternum_quarterday
+operator/(const year_quarternum& yqn, const quarterly::quarterday& qd) NOEXCEPT {
+  return {yqn, qd};
+}
+
+CONSTCD11
+inline
+year_quarternum_quarterday
+operator/(const year_quarternum& yqn, int qd) NOEXCEPT {
+  return yqn / quarterly::quarterday(static_cast<unsigned>(qd));
+}
+
+// year_quarternum_quarterday_last from operator/()
+
+CONSTCD11
+inline
+year_quarternum_quarterday_last
+operator/(const year_quarternum& yqn, quarterly::last_spec) NOEXCEPT {
+  return year_quarternum_quarterday_last{yqn};
+}
+
+} // namespace quarterly_shim
+} // namespace rquarterly
+} // namespace rclock
+
+#endif

--- a/src/quarterly-year-quarter-day.cpp
+++ b/src/quarterly-year-quarter-day.cpp
@@ -1,4 +1,5 @@
 #include "quarterly-year-quarter-day.h"
+#include "quarterly-shim.h"
 #include "calendar.h"
 #include "duration.h"
 #include "check.h"
@@ -64,13 +65,14 @@ year_quarter_day_restore(SEXP x, SEXP to) {
 
 // -----------------------------------------------------------------------------
 
-template <quarterly::start S>
-static
-inline
+[[cpp11::register]]
 cpp11::writable::list
-collect_year_quarter_day_fields_impl(cpp11::list_of<cpp11::integers> fields,
-                                     const cpp11::integers& precision_int) {
+collect_year_quarter_day_fields(cpp11::list_of<cpp11::integers> fields,
+                                const cpp11::integers& precision_int,
+                                const cpp11::integers& start_int) {
   using namespace rclock;
+
+  const quarterly::start start = parse_start(start_int);
 
   cpp11::integers year = rquarterly::get_year(fields);
   cpp11::integers quarter = rquarterly::get_quarter(fields);
@@ -80,15 +82,15 @@ collect_year_quarter_day_fields_impl(cpp11::list_of<cpp11::integers> fields,
   cpp11::integers second = rquarterly::get_second(fields);
   cpp11::integers subsecond = rquarterly::get_subsecond(fields);
 
-  rquarterly::y<S> y{year};
-  rquarterly::yqn<S> yqn{year, quarter};
-  rquarterly::yqnqd<S> yqnqd{year, quarter, day};
-  rquarterly::yqnqdh<S> yqnqdh{year, quarter, day, hour};
-  rquarterly::yqnqdhm<S> yqnqdhm{year, quarter, day, hour, minute};
-  rquarterly::yqnqdhms<S> yqnqdhms{year, quarter, day, hour, minute, second};
-  rquarterly::yqnqdhmss<std::chrono::milliseconds, S> yqnqdhmss1{year, quarter, day, hour, minute, second, subsecond};
-  rquarterly::yqnqdhmss<std::chrono::microseconds, S> yqnqdhmss2{year, quarter, day, hour, minute, second, subsecond};
-  rquarterly::yqnqdhmss<std::chrono::nanoseconds, S> yqnqdhmss3{year, quarter, day, hour, minute, second, subsecond};
+  rquarterly::y y{year, start};
+  rquarterly::yqn yqn{year, quarter, start};
+  rquarterly::yqnqd yqnqd{year, quarter, day, start};
+  rquarterly::yqnqdh yqnqdh{year, quarter, day, hour, start};
+  rquarterly::yqnqdhm yqnqdhm{year, quarter, day, hour, minute, start};
+  rquarterly::yqnqdhms yqnqdhms{year, quarter, day, hour, minute, second, start};
+  rquarterly::yqnqdhmss<std::chrono::milliseconds> yqnqdhmss1{year, quarter, day, hour, minute, second, subsecond, start};
+  rquarterly::yqnqdhmss<std::chrono::microseconds> yqnqdhmss2{year, quarter, day, hour, minute, second, subsecond, start};
+  rquarterly::yqnqdhmss<std::chrono::nanoseconds> yqnqdhmss3{year, quarter, day, hour, minute, second, subsecond, start};
 
   switch (parse_precision(precision_int)) {
   case precision::year: {
@@ -163,43 +165,19 @@ collect_year_quarter_day_fields_impl(cpp11::list_of<cpp11::integers> fields,
   default: clock_abort("Internal error: Invalid precision.");
   }
 
-  never_reached("collect_year_quarter_day_fields_impl");
-}
-
-[[cpp11::register]]
-cpp11::writable::list
-collect_year_quarter_day_fields(cpp11::list_of<cpp11::integers> fields,
-                                const cpp11::integers& precision_int,
-                                const cpp11::integers& start_int) {
-  using namespace quarterly;
-
-  switch (parse_start(start_int)) {
-  case start::january: return collect_year_quarter_day_fields_impl<start::january>(fields, precision_int);
-  case start::february: return collect_year_quarter_day_fields_impl<start::february>(fields, precision_int);
-  case start::march: return collect_year_quarter_day_fields_impl<start::march>(fields, precision_int);
-  case start::april: return collect_year_quarter_day_fields_impl<start::april>(fields, precision_int);
-  case start::may: return collect_year_quarter_day_fields_impl<start::may>(fields, precision_int);
-  case start::june: return collect_year_quarter_day_fields_impl<start::june>(fields, precision_int);
-  case start::july: return collect_year_quarter_day_fields_impl<start::july>(fields, precision_int);
-  case start::august: return collect_year_quarter_day_fields_impl<start::august>(fields, precision_int);
-  case start::september: return collect_year_quarter_day_fields_impl<start::september>(fields, precision_int);
-  case start::october: return collect_year_quarter_day_fields_impl<start::october>(fields, precision_int);
-  case start::november: return collect_year_quarter_day_fields_impl<start::november>(fields, precision_int);
-  case start::december: return collect_year_quarter_day_fields_impl<start::december>(fields, precision_int);
-  }
-
   never_reached("collect_year_quarter_day_fields");
 }
 
 // -----------------------------------------------------------------------------
 
-template <quarterly::start S>
-static
-inline
+[[cpp11::register]]
 cpp11::writable::strings
-format_year_quarter_day_impl(cpp11::list_of<cpp11::integers> fields,
-                             const cpp11::integers& precision_int) {
+format_year_quarter_day_cpp(cpp11::list_of<cpp11::integers> fields,
+                            const cpp11::integers& precision_int,
+                            const cpp11::integers& start_int) {
   using namespace rclock;
+
+  const quarterly::start start = parse_start(start_int);
 
   cpp11::integers year = rquarterly::get_year(fields);
   cpp11::integers quarter = rquarterly::get_quarter(fields);
@@ -209,15 +187,15 @@ format_year_quarter_day_impl(cpp11::list_of<cpp11::integers> fields,
   cpp11::integers second = rquarterly::get_second(fields);
   cpp11::integers subsecond = rquarterly::get_subsecond(fields);
 
-  rquarterly::y<S> y{year};
-  rquarterly::yqn<S> yqn{year, quarter};
-  rquarterly::yqnqd<S> yqnqd{year, quarter, day};
-  rquarterly::yqnqdh<S> yqnqdh{year, quarter, day, hour};
-  rquarterly::yqnqdhm<S> yqnqdhm{year, quarter, day, hour, minute};
-  rquarterly::yqnqdhms<S> yqnqdhms{year, quarter, day, hour, minute, second};
-  rquarterly::yqnqdhmss<std::chrono::milliseconds, S> yqnqdhmss1{year, quarter, day, hour, minute, second, subsecond};
-  rquarterly::yqnqdhmss<std::chrono::microseconds, S> yqnqdhmss2{year, quarter, day, hour, minute, second, subsecond};
-  rquarterly::yqnqdhmss<std::chrono::nanoseconds, S> yqnqdhmss3{year, quarter, day, hour, minute, second, subsecond};
+  rquarterly::y y{year, start};
+  rquarterly::yqn yqn{year, quarter, start};
+  rquarterly::yqnqd yqnqd{year, quarter, day, start};
+  rquarterly::yqnqdh yqnqdh{year, quarter, day, hour, start};
+  rquarterly::yqnqdhm yqnqdhm{year, quarter, day, hour, minute, start};
+  rquarterly::yqnqdhms yqnqdhms{year, quarter, day, hour, minute, second, start};
+  rquarterly::yqnqdhmss<std::chrono::milliseconds> yqnqdhmss1{year, quarter, day, hour, minute, second, subsecond, start};
+  rquarterly::yqnqdhmss<std::chrono::microseconds> yqnqdhmss2{year, quarter, day, hour, minute, second, subsecond, start};
+  rquarterly::yqnqdhmss<std::chrono::nanoseconds> yqnqdhmss3{year, quarter, day, hour, minute, second, subsecond, start};
 
   switch (parse_precision(precision_int)) {
   case precision::year: return format_calendar_impl(y);
@@ -232,41 +210,19 @@ format_year_quarter_day_impl(cpp11::list_of<cpp11::integers> fields,
   default: clock_abort("Internal error: Invalid precision.");
   }
 
-  never_reached("format_year_quarter_day_impl");
-}
-
-[[cpp11::register]]
-cpp11::writable::strings
-format_year_quarter_day_cpp(cpp11::list_of<cpp11::integers> fields,
-                            const cpp11::integers& precision_int,
-                            const cpp11::integers& start_int) {
-  using namespace quarterly;
-
-  switch (parse_start(start_int)) {
-  case start::january: return format_year_quarter_day_impl<start::january>(fields, precision_int);
-  case start::february: return format_year_quarter_day_impl<start::february>(fields, precision_int);
-  case start::march: return format_year_quarter_day_impl<start::march>(fields, precision_int);
-  case start::april: return format_year_quarter_day_impl<start::april>(fields, precision_int);
-  case start::may: return format_year_quarter_day_impl<start::may>(fields, precision_int);
-  case start::june: return format_year_quarter_day_impl<start::june>(fields, precision_int);
-  case start::july: return format_year_quarter_day_impl<start::july>(fields, precision_int);
-  case start::august: return format_year_quarter_day_impl<start::august>(fields, precision_int);
-  case start::september: return format_year_quarter_day_impl<start::september>(fields, precision_int);
-  case start::october: return format_year_quarter_day_impl<start::october>(fields, precision_int);
-  case start::november: return format_year_quarter_day_impl<start::november>(fields, precision_int);
-  case start::december: return format_year_quarter_day_impl<start::december>(fields, precision_int);
-  }
-
   never_reached("format_year_quarter_day_cpp");
 }
 
 // -----------------------------------------------------------------------------
 
-template <quarterly::start S>
+[[cpp11::register]]
 cpp11::writable::logicals
-invalid_detect_year_quarter_day_impl(cpp11::list_of<cpp11::integers> fields,
-                                     const cpp11::integers& precision_int) {
+invalid_detect_year_quarter_day_cpp(cpp11::list_of<cpp11::integers> fields,
+                                    const cpp11::integers& precision_int,
+                                    const cpp11::integers& start_int) {
   using namespace rclock;
+
+  const quarterly::start start = parse_start(start_int);
 
   cpp11::integers year = rquarterly::get_year(fields);
   cpp11::integers quarter = rquarterly::get_quarter(fields);
@@ -276,15 +232,15 @@ invalid_detect_year_quarter_day_impl(cpp11::list_of<cpp11::integers> fields,
   cpp11::integers second = rquarterly::get_second(fields);
   cpp11::integers subsecond = rquarterly::get_subsecond(fields);
 
-  rquarterly::y<S> y{year};
-  rquarterly::yqn<S> yqn{year, quarter};
-  rquarterly::yqnqd<S> yqnqd{year, quarter, day};
-  rquarterly::yqnqdh<S> yqnqdh{year, quarter, day, hour};
-  rquarterly::yqnqdhm<S> yqnqdhm{year, quarter, day, hour, minute};
-  rquarterly::yqnqdhms<S> yqnqdhms{year, quarter, day, hour, minute, second};
-  rquarterly::yqnqdhmss<std::chrono::milliseconds, S> yqnqdhmss1{year, quarter, day, hour, minute, second, subsecond};
-  rquarterly::yqnqdhmss<std::chrono::microseconds, S> yqnqdhmss2{year, quarter, day, hour, minute, second, subsecond};
-  rquarterly::yqnqdhmss<std::chrono::nanoseconds, S> yqnqdhmss3{year, quarter, day, hour, minute, second, subsecond};
+  rquarterly::y y{year, start};
+  rquarterly::yqn yqn{year, quarter, start};
+  rquarterly::yqnqd yqnqd{year, quarter, day, start};
+  rquarterly::yqnqdh yqnqdh{year, quarter, day, hour, start};
+  rquarterly::yqnqdhm yqnqdhm{year, quarter, day, hour, minute, start};
+  rquarterly::yqnqdhms yqnqdhms{year, quarter, day, hour, minute, second, start};
+  rquarterly::yqnqdhmss<std::chrono::milliseconds> yqnqdhmss1{year, quarter, day, hour, minute, second, subsecond, start};
+  rquarterly::yqnqdhmss<std::chrono::microseconds> yqnqdhmss2{year, quarter, day, hour, minute, second, subsecond, start};
+  rquarterly::yqnqdhmss<std::chrono::nanoseconds> yqnqdhmss3{year, quarter, day, hour, minute, second, subsecond, start};
 
   switch (parse_precision(precision_int)) {
   case precision::year: return invalid_detect_calendar_impl(y);
@@ -299,43 +255,19 @@ invalid_detect_year_quarter_day_impl(cpp11::list_of<cpp11::integers> fields,
   default: clock_abort("Internal error: Invalid precision.");
   }
 
-  never_reached("invalid_detect_year_quarter_day_impl");
-}
-
-[[cpp11::register]]
-cpp11::writable::logicals
-invalid_detect_year_quarter_day_cpp(cpp11::list_of<cpp11::integers> fields,
-                                    const cpp11::integers& precision_int,
-                                    const cpp11::integers& start_int) {
-  using namespace quarterly;
-
-  switch (parse_start(start_int)) {
-  case start::january: return invalid_detect_year_quarter_day_impl<start::january>(fields, precision_int);
-  case start::february: return invalid_detect_year_quarter_day_impl<start::february>(fields, precision_int);
-  case start::march: return invalid_detect_year_quarter_day_impl<start::march>(fields, precision_int);
-  case start::april: return invalid_detect_year_quarter_day_impl<start::april>(fields, precision_int);
-  case start::may: return invalid_detect_year_quarter_day_impl<start::may>(fields, precision_int);
-  case start::june: return invalid_detect_year_quarter_day_impl<start::june>(fields, precision_int);
-  case start::july: return invalid_detect_year_quarter_day_impl<start::july>(fields, precision_int);
-  case start::august: return invalid_detect_year_quarter_day_impl<start::august>(fields, precision_int);
-  case start::september: return invalid_detect_year_quarter_day_impl<start::september>(fields, precision_int);
-  case start::october: return invalid_detect_year_quarter_day_impl<start::october>(fields, precision_int);
-  case start::november: return invalid_detect_year_quarter_day_impl<start::november>(fields, precision_int);
-  case start::december: return invalid_detect_year_quarter_day_impl<start::december>(fields, precision_int);
-  }
-
   never_reached("invalid_detect_year_quarter_day_cpp");
 }
 
 // -----------------------------------------------------------------------------
 
-template <quarterly::start S>
-static
-inline
+[[cpp11::register]]
 bool
-invalid_any_year_quarter_day_impl(cpp11::list_of<cpp11::integers> fields,
-                                  const cpp11::integers& precision_int) {
+invalid_any_year_quarter_day_cpp(cpp11::list_of<cpp11::integers> fields,
+                                 const cpp11::integers& precision_int,
+                                 const cpp11::integers& start_int) {
   using namespace rclock;
+
+  const quarterly::start start = parse_start(start_int);
 
   cpp11::integers year = rquarterly::get_year(fields);
   cpp11::integers quarter = rquarterly::get_quarter(fields);
@@ -345,15 +277,15 @@ invalid_any_year_quarter_day_impl(cpp11::list_of<cpp11::integers> fields,
   cpp11::integers second = rquarterly::get_second(fields);
   cpp11::integers subsecond = rquarterly::get_subsecond(fields);
 
-  rquarterly::y<S> y{year};
-  rquarterly::yqn<S> yqn{year, quarter};
-  rquarterly::yqnqd<S> yqnqd{year, quarter, day};
-  rquarterly::yqnqdh<S> yqnqdh{year, quarter, day, hour};
-  rquarterly::yqnqdhm<S> yqnqdhm{year, quarter, day, hour, minute};
-  rquarterly::yqnqdhms<S> yqnqdhms{year, quarter, day, hour, minute, second};
-  rquarterly::yqnqdhmss<std::chrono::milliseconds, S> yqnqdhmss1{year, quarter, day, hour, minute, second, subsecond};
-  rquarterly::yqnqdhmss<std::chrono::microseconds, S> yqnqdhmss2{year, quarter, day, hour, minute, second, subsecond};
-  rquarterly::yqnqdhmss<std::chrono::nanoseconds, S> yqnqdhmss3{year, quarter, day, hour, minute, second, subsecond};
+  rquarterly::y y{year, start};
+  rquarterly::yqn yqn{year, quarter, start};
+  rquarterly::yqnqd yqnqd{year, quarter, day, start};
+  rquarterly::yqnqdh yqnqdh{year, quarter, day, hour, start};
+  rquarterly::yqnqdhm yqnqdhm{year, quarter, day, hour, minute, start};
+  rquarterly::yqnqdhms yqnqdhms{year, quarter, day, hour, minute, second, start};
+  rquarterly::yqnqdhmss<std::chrono::milliseconds> yqnqdhmss1{year, quarter, day, hour, minute, second, subsecond, start};
+  rquarterly::yqnqdhmss<std::chrono::microseconds> yqnqdhmss2{year, quarter, day, hour, minute, second, subsecond, start};
+  rquarterly::yqnqdhmss<std::chrono::nanoseconds> yqnqdhmss3{year, quarter, day, hour, minute, second, subsecond, start};
 
   switch (parse_precision(precision_int)) {
   case precision::year: return invalid_any_calendar_impl(y);
@@ -368,43 +300,19 @@ invalid_any_year_quarter_day_impl(cpp11::list_of<cpp11::integers> fields,
   default: clock_abort("Internal error: Invalid precision.");
   }
 
-  never_reached("invalid_any_year_quarter_day_impl");
-}
-
-[[cpp11::register]]
-bool
-invalid_any_year_quarter_day_cpp(cpp11::list_of<cpp11::integers> fields,
-                                 const cpp11::integers& precision_int,
-                                 const cpp11::integers& start_int) {
-  using namespace quarterly;
-
-  switch (parse_start(start_int)) {
-  case start::january: return invalid_any_year_quarter_day_impl<start::january>(fields, precision_int);
-  case start::february: return invalid_any_year_quarter_day_impl<start::february>(fields, precision_int);
-  case start::march: return invalid_any_year_quarter_day_impl<start::march>(fields, precision_int);
-  case start::april: return invalid_any_year_quarter_day_impl<start::april>(fields, precision_int);
-  case start::may: return invalid_any_year_quarter_day_impl<start::may>(fields, precision_int);
-  case start::june: return invalid_any_year_quarter_day_impl<start::june>(fields, precision_int);
-  case start::july: return invalid_any_year_quarter_day_impl<start::july>(fields, precision_int);
-  case start::august: return invalid_any_year_quarter_day_impl<start::august>(fields, precision_int);
-  case start::september: return invalid_any_year_quarter_day_impl<start::september>(fields, precision_int);
-  case start::october: return invalid_any_year_quarter_day_impl<start::october>(fields, precision_int);
-  case start::november: return invalid_any_year_quarter_day_impl<start::november>(fields, precision_int);
-  case start::december: return invalid_any_year_quarter_day_impl<start::december>(fields, precision_int);
-  }
-
   never_reached("invalid_any_year_quarter_day_cpp");
 }
 
 // -----------------------------------------------------------------------------
 
-template <quarterly::start S>
-static
-inline
+[[cpp11::register]]
 int
-invalid_count_year_quarter_day_impl(cpp11::list_of<cpp11::integers> fields,
-                                    const cpp11::integers& precision_int) {
+invalid_count_year_quarter_day_cpp(cpp11::list_of<cpp11::integers> fields,
+                                   const cpp11::integers& precision_int,
+                                   const cpp11::integers& start_int) {
   using namespace rclock;
+
+  const quarterly::start start = parse_start(start_int);
 
   cpp11::integers year = rquarterly::get_year(fields);
   cpp11::integers quarter = rquarterly::get_quarter(fields);
@@ -414,15 +322,15 @@ invalid_count_year_quarter_day_impl(cpp11::list_of<cpp11::integers> fields,
   cpp11::integers second = rquarterly::get_second(fields);
   cpp11::integers subsecond = rquarterly::get_subsecond(fields);
 
-  rquarterly::y<S> y{year};
-  rquarterly::yqn<S> yqn{year, quarter};
-  rquarterly::yqnqd<S> yqnqd{year, quarter, day};
-  rquarterly::yqnqdh<S> yqnqdh{year, quarter, day, hour};
-  rquarterly::yqnqdhm<S> yqnqdhm{year, quarter, day, hour, minute};
-  rquarterly::yqnqdhms<S> yqnqdhms{year, quarter, day, hour, minute, second};
-  rquarterly::yqnqdhmss<std::chrono::milliseconds, S> yqnqdhmss1{year, quarter, day, hour, minute, second, subsecond};
-  rquarterly::yqnqdhmss<std::chrono::microseconds, S> yqnqdhmss2{year, quarter, day, hour, minute, second, subsecond};
-  rquarterly::yqnqdhmss<std::chrono::nanoseconds, S> yqnqdhmss3{year, quarter, day, hour, minute, second, subsecond};
+  rquarterly::y y{year, start};
+  rquarterly::yqn yqn{year, quarter, start};
+  rquarterly::yqnqd yqnqd{year, quarter, day, start};
+  rquarterly::yqnqdh yqnqdh{year, quarter, day, hour, start};
+  rquarterly::yqnqdhm yqnqdhm{year, quarter, day, hour, minute, start};
+  rquarterly::yqnqdhms yqnqdhms{year, quarter, day, hour, minute, second, start};
+  rquarterly::yqnqdhmss<std::chrono::milliseconds> yqnqdhmss1{year, quarter, day, hour, minute, second, subsecond, start};
+  rquarterly::yqnqdhmss<std::chrono::microseconds> yqnqdhmss2{year, quarter, day, hour, minute, second, subsecond, start};
+  rquarterly::yqnqdhmss<std::chrono::nanoseconds> yqnqdhmss3{year, quarter, day, hour, minute, second, subsecond, start};
 
   switch (parse_precision(precision_int)) {
   case precision::year: return invalid_count_calendar_impl(y);
@@ -437,44 +345,20 @@ invalid_count_year_quarter_day_impl(cpp11::list_of<cpp11::integers> fields,
   default: clock_abort("Internal error: Invalid precision.");
   }
 
-  never_reached("invalid_count_year_quarter_day_impl");
-}
-
-[[cpp11::register]]
-int
-invalid_count_year_quarter_day_cpp(cpp11::list_of<cpp11::integers> fields,
-                                   const cpp11::integers& precision_int,
-                                   const cpp11::integers& start_int) {
-  using namespace quarterly;
-
-  switch (parse_start(start_int)) {
-  case start::january: return invalid_count_year_quarter_day_impl<start::january>(fields, precision_int);
-  case start::february: return invalid_count_year_quarter_day_impl<start::february>(fields, precision_int);
-  case start::march: return invalid_count_year_quarter_day_impl<start::march>(fields, precision_int);
-  case start::april: return invalid_count_year_quarter_day_impl<start::april>(fields, precision_int);
-  case start::may: return invalid_count_year_quarter_day_impl<start::may>(fields, precision_int);
-  case start::june: return invalid_count_year_quarter_day_impl<start::june>(fields, precision_int);
-  case start::july: return invalid_count_year_quarter_day_impl<start::july>(fields, precision_int);
-  case start::august: return invalid_count_year_quarter_day_impl<start::august>(fields, precision_int);
-  case start::september: return invalid_count_year_quarter_day_impl<start::september>(fields, precision_int);
-  case start::october: return invalid_count_year_quarter_day_impl<start::october>(fields, precision_int);
-  case start::november: return invalid_count_year_quarter_day_impl<start::november>(fields, precision_int);
-  case start::december: return invalid_count_year_quarter_day_impl<start::december>(fields, precision_int);
-  }
-
   never_reached("invalid_count_year_quarter_day_cpp");
 }
 
 // -----------------------------------------------------------------------------
 
-template <quarterly::start S>
-static
-inline
+[[cpp11::register]]
 cpp11::writable::list
-invalid_resolve_year_quarter_day_impl(cpp11::list_of<cpp11::integers> fields,
-                                      const cpp11::integers& precision_int,
-                                      const cpp11::strings& invalid_string) {
+invalid_resolve_year_quarter_day_cpp(cpp11::list_of<cpp11::integers> fields,
+                                     const cpp11::integers& precision_int,
+                                     const cpp11::integers& start_int,
+                                     const cpp11::strings& invalid_string) {
   using namespace rclock;
+
+  const quarterly::start start = parse_start(start_int);
   const enum invalid invalid_val = parse_invalid(invalid_string);
 
   cpp11::integers year = rquarterly::get_year(fields);
@@ -485,15 +369,15 @@ invalid_resolve_year_quarter_day_impl(cpp11::list_of<cpp11::integers> fields,
   cpp11::integers second = rquarterly::get_second(fields);
   cpp11::integers subsecond = rquarterly::get_subsecond(fields);
 
-  rquarterly::y<S> y{year};
-  rquarterly::yqn<S> yqn{year, quarter};
-  rquarterly::yqnqd<S> yqnqd{year, quarter, day};
-  rquarterly::yqnqdh<S> yqnqdh{year, quarter, day, hour};
-  rquarterly::yqnqdhm<S> yqnqdhm{year, quarter, day, hour, minute};
-  rquarterly::yqnqdhms<S> yqnqdhms{year, quarter, day, hour, minute, second};
-  rquarterly::yqnqdhmss<std::chrono::milliseconds, S> yqnqdhmss1{year, quarter, day, hour, minute, second, subsecond};
-  rquarterly::yqnqdhmss<std::chrono::microseconds, S> yqnqdhmss2{year, quarter, day, hour, minute, second, subsecond};
-  rquarterly::yqnqdhmss<std::chrono::nanoseconds, S> yqnqdhmss3{year, quarter, day, hour, minute, second, subsecond};
+  rquarterly::y y{year, start};
+  rquarterly::yqn yqn{year, quarter, start};
+  rquarterly::yqnqd yqnqd{year, quarter, day, start};
+  rquarterly::yqnqdh yqnqdh{year, quarter, day, hour, start};
+  rquarterly::yqnqdhm yqnqdhm{year, quarter, day, hour, minute, start};
+  rquarterly::yqnqdhms yqnqdhms{year, quarter, day, hour, minute, second, start};
+  rquarterly::yqnqdhmss<std::chrono::milliseconds> yqnqdhmss1{year, quarter, day, hour, minute, second, subsecond, start};
+  rquarterly::yqnqdhmss<std::chrono::microseconds> yqnqdhmss2{year, quarter, day, hour, minute, second, subsecond, start};
+  rquarterly::yqnqdhmss<std::chrono::nanoseconds> yqnqdhmss3{year, quarter, day, hour, minute, second, subsecond, start};
 
   switch (parse_precision(precision_int)) {
   case precision::year: return invalid_resolve_calendar_impl(y, invalid_val);
@@ -508,45 +392,22 @@ invalid_resolve_year_quarter_day_impl(cpp11::list_of<cpp11::integers> fields,
   default: clock_abort("Internal error: Invalid precision.");
   }
 
-  never_reached("invalid_resolve_year_quarter_day_impl");
-}
-
-[[cpp11::register]]
-cpp11::writable::list
-invalid_resolve_year_quarter_day_cpp(cpp11::list_of<cpp11::integers> fields,
-                                     const cpp11::integers& precision_int,
-                                     const cpp11::integers& start_int,
-                                     const cpp11::strings& invalid_string) {
-  using namespace quarterly;
-
-  switch (parse_start(start_int)) {
-  case start::january: return invalid_resolve_year_quarter_day_impl<start::january>(fields, precision_int, invalid_string);
-  case start::february: return invalid_resolve_year_quarter_day_impl<start::february>(fields, precision_int, invalid_string);
-  case start::march: return invalid_resolve_year_quarter_day_impl<start::march>(fields, precision_int, invalid_string);
-  case start::april: return invalid_resolve_year_quarter_day_impl<start::april>(fields, precision_int, invalid_string);
-  case start::may: return invalid_resolve_year_quarter_day_impl<start::may>(fields, precision_int, invalid_string);
-  case start::june: return invalid_resolve_year_quarter_day_impl<start::june>(fields, precision_int, invalid_string);
-  case start::july: return invalid_resolve_year_quarter_day_impl<start::july>(fields, precision_int, invalid_string);
-  case start::august: return invalid_resolve_year_quarter_day_impl<start::august>(fields, precision_int, invalid_string);
-  case start::september: return invalid_resolve_year_quarter_day_impl<start::september>(fields, precision_int, invalid_string);
-  case start::october: return invalid_resolve_year_quarter_day_impl<start::october>(fields, precision_int, invalid_string);
-  case start::november: return invalid_resolve_year_quarter_day_impl<start::november>(fields, precision_int, invalid_string);
-  case start::december: return invalid_resolve_year_quarter_day_impl<start::december>(fields, precision_int, invalid_string);
-  }
-
   never_reached("invalid_resolve_year_quarter_day_cpp");
 }
 
 // -----------------------------------------------------------------------------
 
-template <quarterly::start S>
-static
+[[cpp11::register]]
 cpp11::writable::list
-set_field_year_quarter_day_impl(cpp11::list_of<cpp11::integers> fields,
-                                const cpp11::integers& value,
-                                const cpp11::integers& precision_fields,
-                                const cpp11::integers& precision_value) {
+set_field_year_quarter_day_cpp(cpp11::list_of<cpp11::integers> fields,
+                               const cpp11::integers& value,
+                               const cpp11::integers& precision_fields,
+                               const cpp11::integers& precision_value,
+                               const cpp11::integers& start_int) {
   using namespace rclock;
+
+  const quarterly::start start = parse_start(start_int);
+
   rclock::integers value2(value);
 
   cpp11::integers year = rquarterly::get_year(fields);
@@ -557,15 +418,15 @@ set_field_year_quarter_day_impl(cpp11::list_of<cpp11::integers> fields,
   cpp11::integers second = rquarterly::get_second(fields);
   cpp11::integers subsecond = rquarterly::get_subsecond(fields);
 
-  rquarterly::y<S> y{year};
-  rquarterly::yqn<S> yqn{year, quarter};
-  rquarterly::yqnqd<S> yqnqd{year, quarter, day};
-  rquarterly::yqnqdh<S> yqnqdh{year, quarter, day, hour};
-  rquarterly::yqnqdhm<S> yqnqdhm{year, quarter, day, hour, minute};
-  rquarterly::yqnqdhms<S> yqnqdhms{year, quarter, day, hour, minute, second};
-  rquarterly::yqnqdhmss<std::chrono::milliseconds, S> yqnqdhmss1{year, quarter, day, hour, minute, second, subsecond};
-  rquarterly::yqnqdhmss<std::chrono::microseconds, S> yqnqdhmss2{year, quarter, day, hour, minute, second, subsecond};
-  rquarterly::yqnqdhmss<std::chrono::nanoseconds, S> yqnqdhmss3{year, quarter, day, hour, minute, second, subsecond};
+  rquarterly::y y{year, start};
+  rquarterly::yqn yqn{year, quarter, start};
+  rquarterly::yqnqd yqnqd{year, quarter, day, start};
+  rquarterly::yqnqdh yqnqdh{year, quarter, day, hour, start};
+  rquarterly::yqnqdhm yqnqdhm{year, quarter, day, hour, minute, start};
+  rquarterly::yqnqdhms yqnqdhms{year, quarter, day, hour, minute, second, start};
+  rquarterly::yqnqdhmss<std::chrono::milliseconds> yqnqdhmss1{year, quarter, day, hour, minute, second, subsecond, start};
+  rquarterly::yqnqdhmss<std::chrono::microseconds> yqnqdhmss2{year, quarter, day, hour, minute, second, subsecond, start};
+  rquarterly::yqnqdhmss<std::chrono::nanoseconds> yqnqdhmss3{year, quarter, day, hour, minute, second, subsecond, start};
 
   switch (parse_precision(precision_fields)) {
   case precision::year: {
@@ -666,37 +527,10 @@ set_field_year_quarter_day_impl(cpp11::list_of<cpp11::integers> fields,
   default: clock_abort("Internal error: Invalid precision.");
   }
 
-  never_reached("set_field_year_quarter_day_impl");
-}
-
-[[cpp11::register]]
-cpp11::writable::list
-set_field_year_quarter_day_cpp(cpp11::list_of<cpp11::integers> fields,
-                               const cpp11::integers& value,
-                               const cpp11::integers& precision_fields,
-                               const cpp11::integers& precision_value,
-                               const cpp11::integers& start_int) {
-  using namespace quarterly;
-
-  switch (parse_start(start_int)) {
-  case start::january: return set_field_year_quarter_day_impl<start::january>(fields, value, precision_fields, precision_value);
-  case start::february: return set_field_year_quarter_day_impl<start::february>(fields, value, precision_fields, precision_value);
-  case start::march: return set_field_year_quarter_day_impl<start::march>(fields, value, precision_fields, precision_value);
-  case start::april: return set_field_year_quarter_day_impl<start::april>(fields, value, precision_fields, precision_value);
-  case start::may: return set_field_year_quarter_day_impl<start::may>(fields, value, precision_fields, precision_value);
-  case start::june: return set_field_year_quarter_day_impl<start::june>(fields, value, precision_fields, precision_value);
-  case start::july: return set_field_year_quarter_day_impl<start::july>(fields, value, precision_fields, precision_value);
-  case start::august: return set_field_year_quarter_day_impl<start::august>(fields, value, precision_fields, precision_value);
-  case start::september: return set_field_year_quarter_day_impl<start::september>(fields, value, precision_fields, precision_value);
-  case start::october: return set_field_year_quarter_day_impl<start::october>(fields, value, precision_fields, precision_value);
-  case start::november: return set_field_year_quarter_day_impl<start::november>(fields, value, precision_fields, precision_value);
-  case start::december: return set_field_year_quarter_day_impl<start::december>(fields, value, precision_fields, precision_value);
-  }
-
   never_reached("set_field_year_quarter_day_cpp");
 }
 
-template <quarterly::start S, class Calendar>
+template <class Calendar>
 cpp11::writable::list
 set_field_year_quarter_day_last_impl(const Calendar& x) {
   const r_ssize size = x.size();
@@ -706,7 +540,7 @@ set_field_year_quarter_day_last_impl(const Calendar& x) {
     if (x.is_na(i)) {
       value[i] = r_int_na;
     } else {
-      quarterly::year_quarternum_quarterday<S> yqnqdl = x.to_year_quarternum(i) / quarterly::last;
+      rclock::rquarterly::quarterly_shim::year_quarternum_quarterday_last yqnqdl{x.to_year_quarternum(i)};
       value[i] = static_cast<int>(static_cast<unsigned>(yqnqdl.quarterday()));
     }
   }
@@ -717,11 +551,14 @@ set_field_year_quarter_day_last_impl(const Calendar& x) {
   return out;
 }
 
-template <quarterly::start S>
+[[cpp11::register]]
 cpp11::writable::list
-set_field_year_quarter_day_last_switch(cpp11::list_of<cpp11::integers> fields,
-                                       const cpp11::integers& precision_fields) {
+set_field_year_quarter_day_last_cpp(cpp11::list_of<cpp11::integers> fields,
+                                    const cpp11::integers& precision_fields,
+                                    const cpp11::integers& start_int) {
   using namespace rclock;
+
+  const quarterly::start start = parse_start(start_int);
 
   cpp11::integers year = rquarterly::get_year(fields);
   cpp11::integers quarter = rquarterly::get_quarter(fields);
@@ -731,51 +568,25 @@ set_field_year_quarter_day_last_switch(cpp11::list_of<cpp11::integers> fields,
   cpp11::integers second = rquarterly::get_second(fields);
   cpp11::integers subsecond = rquarterly::get_subsecond(fields);
 
-  rquarterly::y<S> y{year};
-  rquarterly::yqn<S> yqn{year, quarter};
-  rquarterly::yqnqd<S> yqnqd{year, quarter, day};
-  rquarterly::yqnqdh<S> yqnqdh{year, quarter, day, hour};
-  rquarterly::yqnqdhm<S> yqnqdhm{year, quarter, day, hour, minute};
-  rquarterly::yqnqdhms<S> yqnqdhms{year, quarter, day, hour, minute, second};
-  rquarterly::yqnqdhmss<std::chrono::milliseconds, S> yqnqdhmss1{year, quarter, day, hour, minute, second, subsecond};
-  rquarterly::yqnqdhmss<std::chrono::microseconds, S> yqnqdhmss2{year, quarter, day, hour, minute, second, subsecond};
-  rquarterly::yqnqdhmss<std::chrono::nanoseconds, S> yqnqdhmss3{year, quarter, day, hour, minute, second, subsecond};
+  rquarterly::yqn yqn{year, quarter, start};
+  rquarterly::yqnqd yqnqd{year, quarter, day, start};
+  rquarterly::yqnqdh yqnqdh{year, quarter, day, hour, start};
+  rquarterly::yqnqdhm yqnqdhm{year, quarter, day, hour, minute, start};
+  rquarterly::yqnqdhms yqnqdhms{year, quarter, day, hour, minute, second, start};
+  rquarterly::yqnqdhmss<std::chrono::milliseconds> yqnqdhmss1{year, quarter, day, hour, minute, second, subsecond, start};
+  rquarterly::yqnqdhmss<std::chrono::microseconds> yqnqdhmss2{year, quarter, day, hour, minute, second, subsecond, start};
+  rquarterly::yqnqdhmss<std::chrono::nanoseconds> yqnqdhmss3{year, quarter, day, hour, minute, second, subsecond, start};
 
   switch (parse_precision(precision_fields)) {
-  case precision::quarter: return set_field_year_quarter_day_last_impl<S>(yqn);
-  case precision::day: return set_field_year_quarter_day_last_impl<S>(yqnqd);
-  case precision::hour: return set_field_year_quarter_day_last_impl<S>(yqnqdh);
-  case precision::minute: return set_field_year_quarter_day_last_impl<S>(yqnqdhm);
-  case precision::second: return set_field_year_quarter_day_last_impl<S>(yqnqdhms);
-  case precision::millisecond: return set_field_year_quarter_day_last_impl<S>(yqnqdhmss1);
-  case precision::microsecond: return set_field_year_quarter_day_last_impl<S>(yqnqdhmss2);
-  case precision::nanosecond: return set_field_year_quarter_day_last_impl<S>(yqnqdhmss3);
+  case precision::quarter: return set_field_year_quarter_day_last_impl(yqn);
+  case precision::day: return set_field_year_quarter_day_last_impl(yqnqd);
+  case precision::hour: return set_field_year_quarter_day_last_impl(yqnqdh);
+  case precision::minute: return set_field_year_quarter_day_last_impl(yqnqdhm);
+  case precision::second: return set_field_year_quarter_day_last_impl(yqnqdhms);
+  case precision::millisecond: return set_field_year_quarter_day_last_impl(yqnqdhmss1);
+  case precision::microsecond: return set_field_year_quarter_day_last_impl(yqnqdhmss2);
+  case precision::nanosecond: return set_field_year_quarter_day_last_impl(yqnqdhmss3);
   default: clock_abort("Internal error: Invalid precision.");
-  }
-
-  never_reached("set_field_year_quarter_day_last_switch");
-}
-
-[[cpp11::register]]
-cpp11::writable::list
-set_field_year_quarter_day_last_cpp(cpp11::list_of<cpp11::integers> fields,
-                                    const cpp11::integers& precision_fields,
-                                    const cpp11::integers& start_int) {
-  using namespace quarterly;
-
-  switch (parse_start(start_int)) {
-  case start::january: return set_field_year_quarter_day_last_switch<start::january>(fields, precision_fields);
-  case start::february: return set_field_year_quarter_day_last_switch<start::february>(fields, precision_fields);
-  case start::march: return set_field_year_quarter_day_last_switch<start::march>(fields, precision_fields);
-  case start::april: return set_field_year_quarter_day_last_switch<start::april>(fields, precision_fields);
-  case start::may: return set_field_year_quarter_day_last_switch<start::may>(fields, precision_fields);
-  case start::june: return set_field_year_quarter_day_last_switch<start::june>(fields, precision_fields);
-  case start::july: return set_field_year_quarter_day_last_switch<start::july>(fields, precision_fields);
-  case start::august: return set_field_year_quarter_day_last_switch<start::august>(fields, precision_fields);
-  case start::september: return set_field_year_quarter_day_last_switch<start::september>(fields, precision_fields);
-  case start::october: return set_field_year_quarter_day_last_switch<start::october>(fields, precision_fields);
-  case start::november: return set_field_year_quarter_day_last_switch<start::november>(fields, precision_fields);
-  case start::december: return set_field_year_quarter_day_last_switch<start::december>(fields, precision_fields);
   }
 
   never_reached("set_field_year_quarter_day_last_cpp");
@@ -783,13 +594,16 @@ set_field_year_quarter_day_last_cpp(cpp11::list_of<cpp11::integers> fields,
 
 // -----------------------------------------------------------------------------
 
-template <quarterly::start S>
+[[cpp11::register]]
 cpp11::writable::list
-year_quarter_day_plus_duration_impl(cpp11::list_of<cpp11::integers> fields,
-                                    cpp11::list_of<cpp11::integers> fields_n,
-                                    const cpp11::integers& precision_fields,
-                                    const cpp11::integers& precision_n) {
+year_quarter_day_plus_duration_cpp(cpp11::list_of<cpp11::integers> fields,
+                                   cpp11::list_of<cpp11::integers> fields_n,
+                                   const cpp11::integers& precision_fields,
+                                   const cpp11::integers& precision_n,
+                                   const cpp11::integers& start_int) {
   using namespace rclock;
+
+  const quarterly::start start = parse_start(start_int);
 
   const enum precision precision_fields_val = parse_precision(precision_fields);
   const enum precision precision_n_val = parse_precision(precision_n);
@@ -802,15 +616,15 @@ year_quarter_day_plus_duration_impl(cpp11::list_of<cpp11::integers> fields,
   cpp11::integers second = rquarterly::get_second(fields);
   cpp11::integers subsecond = rquarterly::get_subsecond(fields);
 
-  rquarterly::y<S> y{year};
-  rquarterly::yqn<S> yqn{year, quarter};
-  rquarterly::yqnqd<S> yqnqd{year, quarter, day};
-  rquarterly::yqnqdh<S> yqnqdh{year, quarter, day, hour};
-  rquarterly::yqnqdhm<S> yqnqdhm{year, quarter, day, hour, minute};
-  rquarterly::yqnqdhms<S> yqnqdhms{year, quarter, day, hour, minute, second};
-  rquarterly::yqnqdhmss<std::chrono::milliseconds, S> yqnqdhmss1{year, quarter, day, hour, minute, second, subsecond};
-  rquarterly::yqnqdhmss<std::chrono::microseconds, S> yqnqdhmss2{year, quarter, day, hour, minute, second, subsecond};
-  rquarterly::yqnqdhmss<std::chrono::nanoseconds, S> yqnqdhmss3{year, quarter, day, hour, minute, second, subsecond};
+  rquarterly::y y{year, start};
+  rquarterly::yqn yqn{year, quarter, start};
+  rquarterly::yqnqd yqnqd{year, quarter, day, start};
+  rquarterly::yqnqdh yqnqdh{year, quarter, day, hour, start};
+  rquarterly::yqnqdhm yqnqdhm{year, quarter, day, hour, minute, start};
+  rquarterly::yqnqdhms yqnqdhms{year, quarter, day, hour, minute, second, start};
+  rquarterly::yqnqdhmss<std::chrono::milliseconds> yqnqdhmss1{year, quarter, day, hour, minute, second, subsecond, start};
+  rquarterly::yqnqdhmss<std::chrono::microseconds> yqnqdhmss2{year, quarter, day, hour, minute, second, subsecond, start};
+  rquarterly::yqnqdhmss<std::chrono::nanoseconds> yqnqdhmss3{year, quarter, day, hour, minute, second, subsecond, start};
 
   cpp11::integers ticks = duration::get_ticks(fields_n);
 
@@ -874,43 +688,19 @@ year_quarter_day_plus_duration_impl(cpp11::list_of<cpp11::integers> fields,
   default: clock_abort("Internal error: Invalid precision.");
   }
 
-  never_reached("year_quarter_day_plus_duration_impl");
-}
-
-[[cpp11::register]]
-cpp11::writable::list
-year_quarter_day_plus_duration_cpp(cpp11::list_of<cpp11::integers> fields,
-                                   cpp11::list_of<cpp11::integers> fields_n,
-                                   const cpp11::integers& precision_fields,
-                                   const cpp11::integers& precision_n,
-                                   const cpp11::integers& start_int) {
-  using namespace quarterly;
-
-  switch (parse_start(start_int)) {
-  case start::january: return year_quarter_day_plus_duration_impl<start::january>(fields, fields_n, precision_fields, precision_n);
-  case start::february: return year_quarter_day_plus_duration_impl<start::february>(fields, fields_n, precision_fields, precision_n);
-  case start::march: return year_quarter_day_plus_duration_impl<start::march>(fields, fields_n, precision_fields, precision_n);
-  case start::april: return year_quarter_day_plus_duration_impl<start::april>(fields, fields_n, precision_fields, precision_n);
-  case start::may: return year_quarter_day_plus_duration_impl<start::may>(fields, fields_n, precision_fields, precision_n);
-  case start::june: return year_quarter_day_plus_duration_impl<start::june>(fields, fields_n, precision_fields, precision_n);
-  case start::july: return year_quarter_day_plus_duration_impl<start::july>(fields, fields_n, precision_fields, precision_n);
-  case start::august: return year_quarter_day_plus_duration_impl<start::august>(fields, fields_n, precision_fields, precision_n);
-  case start::september: return year_quarter_day_plus_duration_impl<start::september>(fields, fields_n, precision_fields, precision_n);
-  case start::october: return year_quarter_day_plus_duration_impl<start::october>(fields, fields_n, precision_fields, precision_n);
-  case start::november: return year_quarter_day_plus_duration_impl<start::november>(fields, fields_n, precision_fields, precision_n);
-  case start::december: return year_quarter_day_plus_duration_impl<start::december>(fields, fields_n, precision_fields, precision_n);
-  }
-
   never_reached("year_quarter_day_plus_duration_cpp");
 }
 
 // -----------------------------------------------------------------------------
 
-template <quarterly::start S>
+[[cpp11::register]]
 cpp11::writable::list
-as_sys_time_year_quarter_day_impl(cpp11::list_of<cpp11::integers> fields,
-                                  const cpp11::integers& precision_int) {
+as_sys_time_year_quarter_day_cpp(cpp11::list_of<cpp11::integers> fields,
+                                 const cpp11::integers& precision_int,
+                                 const cpp11::integers& start_int) {
   using namespace rclock;
+
+  const quarterly::start start = parse_start(start_int);
 
   cpp11::integers year = rquarterly::get_year(fields);
   cpp11::integers quarter = rquarterly::get_quarter(fields);
@@ -920,15 +710,13 @@ as_sys_time_year_quarter_day_impl(cpp11::list_of<cpp11::integers> fields,
   cpp11::integers second = rquarterly::get_second(fields);
   cpp11::integers subsecond = rquarterly::get_subsecond(fields);
 
-  rquarterly::y<S> y{year};
-  rquarterly::yqn<S> yqn{year, quarter};
-  rquarterly::yqnqd<S> yqnqd{year, quarter, day};
-  rquarterly::yqnqdh<S> yqnqdh{year, quarter, day, hour};
-  rquarterly::yqnqdhm<S> yqnqdhm{year, quarter, day, hour, minute};
-  rquarterly::yqnqdhms<S> yqnqdhms{year, quarter, day, hour, minute, second};
-  rquarterly::yqnqdhmss<std::chrono::milliseconds, S> yqnqdhmss1{year, quarter, day, hour, minute, second, subsecond};
-  rquarterly::yqnqdhmss<std::chrono::microseconds, S> yqnqdhmss2{year, quarter, day, hour, minute, second, subsecond};
-  rquarterly::yqnqdhmss<std::chrono::nanoseconds, S> yqnqdhmss3{year, quarter, day, hour, minute, second, subsecond};
+  rquarterly::yqnqd yqnqd{year, quarter, day, start};
+  rquarterly::yqnqdh yqnqdh{year, quarter, day, hour, start};
+  rquarterly::yqnqdhm yqnqdhm{year, quarter, day, hour, minute, start};
+  rquarterly::yqnqdhms yqnqdhms{year, quarter, day, hour, minute, second, start};
+  rquarterly::yqnqdhmss<std::chrono::milliseconds> yqnqdhmss1{year, quarter, day, hour, minute, second, subsecond, start};
+  rquarterly::yqnqdhmss<std::chrono::microseconds> yqnqdhmss2{year, quarter, day, hour, minute, second, subsecond, start};
+  rquarterly::yqnqdhmss<std::chrono::nanoseconds> yqnqdhmss3{year, quarter, day, hour, minute, second, subsecond, start};
 
   switch (parse_precision(precision_int)) {
   case precision::day: return as_sys_time_from_calendar_impl<duration::days>(yqnqd);
@@ -950,41 +738,39 @@ as_sys_time_year_quarter_day_impl(cpp11::list_of<cpp11::integers> fields,
   }
   }
 
-  never_reached("as_sys_time_year_quarter_day_impl");
-}
-
-[[cpp11::register]]
-cpp11::writable::list
-as_sys_time_year_quarter_day_cpp(cpp11::list_of<cpp11::integers> fields,
-                                 const cpp11::integers& precision_int,
-                                 const cpp11::integers& start_int) {
-  using namespace quarterly;
-
-  switch (parse_start(start_int)) {
-  case start::january: return as_sys_time_year_quarter_day_impl<start::january>(fields, precision_int);
-  case start::february: return as_sys_time_year_quarter_day_impl<start::february>(fields, precision_int);
-  case start::march: return as_sys_time_year_quarter_day_impl<start::march>(fields, precision_int);
-  case start::april: return as_sys_time_year_quarter_day_impl<start::april>(fields, precision_int);
-  case start::may: return as_sys_time_year_quarter_day_impl<start::may>(fields, precision_int);
-  case start::june: return as_sys_time_year_quarter_day_impl<start::june>(fields, precision_int);
-  case start::july: return as_sys_time_year_quarter_day_impl<start::july>(fields, precision_int);
-  case start::august: return as_sys_time_year_quarter_day_impl<start::august>(fields, precision_int);
-  case start::september: return as_sys_time_year_quarter_day_impl<start::september>(fields, precision_int);
-  case start::october: return as_sys_time_year_quarter_day_impl<start::october>(fields, precision_int);
-  case start::november: return as_sys_time_year_quarter_day_impl<start::november>(fields, precision_int);
-  case start::december: return as_sys_time_year_quarter_day_impl<start::december>(fields, precision_int);
-  }
-
   never_reached("as_sys_time_year_quarter_day_cpp");
 }
 
 // -----------------------------------------------------------------------------
 
-template <quarterly::start S>
+template <class Calendar, class ClockDuration>
 cpp11::writable::list
-as_year_quarter_day_from_sys_time_impl(cpp11::list_of<cpp11::integers> fields,
-                                       const cpp11::integers& precision_int) {
+as_year_quarter_day_from_sys_time_impl(const ClockDuration& x, quarterly::start start) {
+  const r_ssize size = x.size();
+  Calendar out(size, start);
+  using Duration = typename ClockDuration::duration;
+
+  for (r_ssize i = 0; i < size; ++i) {
+    if (x.is_na(i)) {
+      out.assign_na(i);
+    } else {
+      Duration elt = x[i];
+      date::sys_time<Duration> elt_st{elt};
+      out.assign_sys_time(elt_st, i);
+    }
+  }
+
+  return out.to_list();
+}
+
+[[cpp11::register]]
+cpp11::writable::list
+as_year_quarter_day_from_sys_time_cpp(cpp11::list_of<cpp11::integers> fields,
+                                      const cpp11::integers& precision_int,
+                                      const cpp11::integers& start_int) {
   using namespace rclock;
+
+  const quarterly::start start = parse_start(start_int);
 
   cpp11::integers ticks = duration::get_ticks(fields);
   cpp11::integers ticks_of_day = duration::get_ticks_of_day(fields);
@@ -999,39 +785,14 @@ as_year_quarter_day_from_sys_time_impl(cpp11::list_of<cpp11::integers> fields,
   duration::nanoseconds dnano{ticks, ticks_of_day, ticks_of_second};
 
   switch (parse_precision(precision_int)) {
-  case precision::day: return as_calendar_from_sys_time_impl<rquarterly::yqnqd<S>>(dd);
-  case precision::hour: return as_calendar_from_sys_time_impl<rquarterly::yqnqdh<S>>(dh);
-  case precision::minute: return as_calendar_from_sys_time_impl<rquarterly::yqnqdhm<S>>(dmin);
-  case precision::second: return as_calendar_from_sys_time_impl<rquarterly::yqnqdhms<S>>(ds);
-  case precision::millisecond: return as_calendar_from_sys_time_impl<rquarterly::yqnqdhmss<std::chrono::milliseconds, S>>(dmilli);
-  case precision::microsecond: return as_calendar_from_sys_time_impl<rquarterly::yqnqdhmss<std::chrono::microseconds, S>>(dmicro);
-  case precision::nanosecond: return as_calendar_from_sys_time_impl<rquarterly::yqnqdhmss<std::chrono::nanoseconds, S>>(dnano);
+  case precision::day: return as_year_quarter_day_from_sys_time_impl<rquarterly::yqnqd>(dd, start);
+  case precision::hour: return as_year_quarter_day_from_sys_time_impl<rquarterly::yqnqdh>(dh, start);
+  case precision::minute: return as_year_quarter_day_from_sys_time_impl<rquarterly::yqnqdhm>(dmin, start);
+  case precision::second: return as_year_quarter_day_from_sys_time_impl<rquarterly::yqnqdhms>(ds, start);
+  case precision::millisecond: return as_year_quarter_day_from_sys_time_impl<rquarterly::yqnqdhmss<std::chrono::milliseconds>>(dmilli, start);
+  case precision::microsecond: return as_year_quarter_day_from_sys_time_impl<rquarterly::yqnqdhmss<std::chrono::microseconds>>(dmicro, start);
+  case precision::nanosecond: return as_year_quarter_day_from_sys_time_impl<rquarterly::yqnqdhmss<std::chrono::nanoseconds>>(dnano, start);
   default: clock_abort("Internal error: Invalid precision.");
-  }
-
-  never_reached("as_year_quarter_day_from_sys_time_impl");
-}
-
-[[cpp11::register]]
-cpp11::writable::list
-as_year_quarter_day_from_sys_time_cpp(cpp11::list_of<cpp11::integers> fields,
-                                      const cpp11::integers& precision_int,
-                                      const cpp11::integers& start_int) {
-  using namespace quarterly;
-
-  switch (parse_start(start_int)) {
-  case start::january: return as_year_quarter_day_from_sys_time_impl<start::january>(fields, precision_int);
-  case start::february: return as_year_quarter_day_from_sys_time_impl<start::february>(fields, precision_int);
-  case start::march: return as_year_quarter_day_from_sys_time_impl<start::march>(fields, precision_int);
-  case start::april: return as_year_quarter_day_from_sys_time_impl<start::april>(fields, precision_int);
-  case start::may: return as_year_quarter_day_from_sys_time_impl<start::may>(fields, precision_int);
-  case start::june: return as_year_quarter_day_from_sys_time_impl<start::june>(fields, precision_int);
-  case start::july: return as_year_quarter_day_from_sys_time_impl<start::july>(fields, precision_int);
-  case start::august: return as_year_quarter_day_from_sys_time_impl<start::august>(fields, precision_int);
-  case start::september: return as_year_quarter_day_from_sys_time_impl<start::september>(fields, precision_int);
-  case start::october: return as_year_quarter_day_from_sys_time_impl<start::october>(fields, precision_int);
-  case start::november: return as_year_quarter_day_from_sys_time_impl<start::november>(fields, precision_int);
-  case start::december: return as_year_quarter_day_from_sys_time_impl<start::december>(fields, precision_int);
   }
 
   never_reached("as_year_quarter_day_from_sys_time_cpp");
@@ -1039,12 +800,11 @@ as_year_quarter_day_from_sys_time_cpp(cpp11::list_of<cpp11::integers> fields,
 
 // -----------------------------------------------------------------------------
 
-template <quarterly::start S>
 static
 inline
 cpp11::writable::list
-year_minus_year_impl(const rclock::rquarterly::y<S>& x,
-                     const rclock::rquarterly::y<S>& y) {
+year_minus_year_impl(const rclock::rquarterly::y& x,
+                     const rclock::rquarterly::y& y) {
   const r_ssize size = x.size();
   rclock::duration::years out(size);
 
@@ -1059,12 +819,11 @@ year_minus_year_impl(const rclock::rquarterly::y<S>& x,
   return out.to_list();
 }
 
-template <quarterly::start S>
 static
 inline
 cpp11::writable::list
-year_quarter_minus_year_quarter_impl(const rclock::rquarterly::yqn<S>& x,
-                                     const rclock::rquarterly::yqn<S>& y) {
+year_quarter_minus_year_quarter_impl(const rclock::rquarterly::yqn& x,
+                                     const rclock::rquarterly::yqn& y) {
   const r_ssize size = x.size();
   rclock::duration::quarters out(size);
 
@@ -1079,53 +838,30 @@ year_quarter_minus_year_quarter_impl(const rclock::rquarterly::yqn<S>& x,
   return out.to_list();
 }
 
-template <quarterly::start S>
-cpp11::writable::list
-year_quarter_day_minus_year_quarter_day_impl(cpp11::list_of<cpp11::integers> x,
-                                             cpp11::list_of<cpp11::integers> y,
-                                             const cpp11::integers& precision_int) {
-  const cpp11::integers x_year = rclock::rquarterly::get_year(x);
-  const cpp11::integers x_quarter = rclock::rquarterly::get_quarter(x);
-
-  const cpp11::integers y_year = rclock::rquarterly::get_year(y);
-  const cpp11::integers y_quarter = rclock::rquarterly::get_quarter(y);
-
-  const rclock::rquarterly::y<S> x_y{x_year};
-  const rclock::rquarterly::yqn<S> x_yqn{x_year, x_quarter};
-
-  const rclock::rquarterly::y<S> y_y{y_year};
-  const rclock::rquarterly::yqn<S> y_yqn{y_year, y_quarter};
-
-  switch (parse_precision(precision_int)) {
-  case precision::year: return year_minus_year_impl(x_y, y_y);
-  case precision::quarter: return year_quarter_minus_year_quarter_impl(x_yqn, y_yqn);
-  default: clock_abort("Internal error: Invalid precision.");
-  }
-
-  never_reached("year_quarter_day_minus_year_quarter_day_impl");
-}
-
 [[cpp11::register]]
 cpp11::writable::list
 year_quarter_day_minus_year_quarter_day_cpp(cpp11::list_of<cpp11::integers> x,
                                             cpp11::list_of<cpp11::integers> y,
                                             const cpp11::integers& precision_int,
                                             const cpp11::integers& start_int) {
-  using namespace quarterly;
+  quarterly::start start = parse_start(start_int);
 
-  switch (parse_start(start_int)) {
-  case start::january: return year_quarter_day_minus_year_quarter_day_impl<start::january>(x, y, precision_int);
-  case start::february: return year_quarter_day_minus_year_quarter_day_impl<start::february>(x, y, precision_int);
-  case start::march: return year_quarter_day_minus_year_quarter_day_impl<start::march>(x, y, precision_int);
-  case start::april: return year_quarter_day_minus_year_quarter_day_impl<start::april>(x, y, precision_int);
-  case start::may: return year_quarter_day_minus_year_quarter_day_impl<start::may>(x, y, precision_int);
-  case start::june: return year_quarter_day_minus_year_quarter_day_impl<start::june>(x, y, precision_int);
-  case start::july: return year_quarter_day_minus_year_quarter_day_impl<start::july>(x, y, precision_int);
-  case start::august: return year_quarter_day_minus_year_quarter_day_impl<start::august>(x, y, precision_int);
-  case start::september: return year_quarter_day_minus_year_quarter_day_impl<start::september>(x, y, precision_int);
-  case start::october: return year_quarter_day_minus_year_quarter_day_impl<start::october>(x, y, precision_int);
-  case start::november: return year_quarter_day_minus_year_quarter_day_impl<start::november>(x, y, precision_int);
-  case start::december: return year_quarter_day_minus_year_quarter_day_impl<start::december>(x, y, precision_int);
+  const cpp11::integers x_year = rclock::rquarterly::get_year(x);
+  const cpp11::integers x_quarter = rclock::rquarterly::get_quarter(x);
+
+  const cpp11::integers y_year = rclock::rquarterly::get_year(y);
+  const cpp11::integers y_quarter = rclock::rquarterly::get_quarter(y);
+
+  const rclock::rquarterly::y x_y{x_year, start};
+  const rclock::rquarterly::yqn x_yqn{x_year, x_quarter, start};
+
+  const rclock::rquarterly::y y_y{y_year, start};
+  const rclock::rquarterly::yqn y_yqn{y_year, y_quarter, start};
+
+  switch (parse_precision(precision_int)) {
+  case precision::year: return year_minus_year_impl(x_y, y_y);
+  case precision::quarter: return year_quarter_minus_year_quarter_impl(x_yqn, y_yqn);
+  default: clock_abort("Internal error: Invalid precision.");
   }
 
   never_reached("year_quarter_day_minus_year_quarter_day_cpp");


### PR DESCRIPTION
To greatly improve compilation speed

Basically, `quarterly-year-quarter-day.cpp` needed every function to be templated on both the precision and the quarter start, which resulted in a massive explosion in the amount of template code that had to be generated.

We don't _really_ need templating on the quarter start, even though using a template in `quarterly.h` is technically correct (because it is part of the type definition). So this introduces a _minimal_ shim around those classes that re-exposes them in a template free way.

The shim doesn't expose everything from `quarterly.h`, only what is needed for the R API. We can expose more as needed.

Essentially the template parameter is now a class member `quarterly_shim::year`. We went:

```cpp
// from
quarterly::year<start>

// to
quarterly_shim::year.start()
```

On my 2018 Intel Mac, compilation time went down from 70s to 25s!