### PR TITLE
Take ownership of the read-only data

### DIFF
--- a/src/integers.h
+++ b/src/integers.h
@@ -9,13 +9,13 @@ static const cpp11::integers clock_empty_integers = cpp11::integers{};
 
 class integers
 {
-  const cpp11::integers& read_;
+  const cpp11::integers read_;
   cpp11::writable::integers write_;
   bool writable_;
 
 public:
-  CONSTCD11 integers() NOEXCEPT;
-  CONSTCD11 integers(const cpp11::integers& x) NOEXCEPT;
+  integers() NOEXCEPT;
+  integers(const cpp11::integers& x) NOEXCEPT;
   integers(r_ssize size);
 
   bool is_na(r_ssize i) const NOEXCEPT;
@@ -33,14 +33,12 @@ private:
   void as_writable();
 };
 
-CONSTCD11
 inline
 integers::integers() NOEXCEPT
   : read_(clock_empty_integers),
     writable_(false)
   {}
 
-CONSTCD11
 inline
 integers::integers(const cpp11::integers& x) NOEXCEPT
   : read_(x),


### PR DESCRIPTION
To manage the protection of it, important when `rclock::integers` are being created from "on the fly" vectors

This will be important for some upcoming PRs related to streamlining the calendar code

---

The current approach is honestly a memory protection issue, because you can create a `rclock::integers` from something that can go out of scope before the `rclock::integers` class does.