### PR TITLE
Rework durations and time points on top of 2 double vectors

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,17 @@
 # clock (development version)
 
+* The storage mechanism for the duration, sys-time, naive-time, and zoned-time
+  types has been altered to more correctly represent the full range of values
+  allowed by the underlying C++ types. This means that if you have serialized
+  a value of one of these types with an old version of clock, then it will no
+  longer unserialize correctly going forward.
+  
+  Technically, rather than storing a variable number of integer vectors
+  representing ticks, ticks of a day, and ticks of a second, we now always store
+  values of these types within two double vectors, regardless of the precision.
+  This simplifies the implementation and allows us to represent the full range
+  of possible `int64_t` values (#331).
+
 * clock now compiles significantly faster (on a 2018 Intel Mac, it used to take
   ~70 seconds for a full compilation, and now takes ~25 seconds) (#322).
 

--- a/R/cpp11.R
+++ b/R/cpp11.R
@@ -412,16 +412,16 @@ clock_init_utils <- function() {
   .Call(`_clock_clock_init_utils`)
 }
 
-weekday_add_days_cpp <- function(x, n) {
-  .Call(`_clock_weekday_add_days_cpp`, x, n)
+weekday_add_days_cpp <- function(x, n_fields) {
+  .Call(`_clock_weekday_add_days_cpp`, x, n_fields)
 }
 
 weekday_minus_weekday_cpp <- function(x, y) {
   .Call(`_clock_weekday_minus_weekday_cpp`, x, y)
 }
 
-weekday_from_time_point_cpp <- function(x) {
-  .Call(`_clock_weekday_from_time_point_cpp`, x)
+weekday_from_time_point_cpp <- function(x_fields) {
+  .Call(`_clock_weekday_from_time_point_cpp`, x_fields)
 }
 
 format_weekday_cpp <- function(x, labels) {
@@ -452,8 +452,8 @@ as_zoned_sys_time_from_naive_time_cpp <- function(fields, precision_int, zone, n
   .Call(`_clock_as_zoned_sys_time_from_naive_time_cpp`, fields, precision_int, zone, nonexistent_string, ambiguous_string)
 }
 
-as_zoned_sys_time_from_naive_time_with_reference_cpp <- function(fields, precision_int, zone, nonexistent_string, ambiguous_string, reference) {
-  .Call(`_clock_as_zoned_sys_time_from_naive_time_with_reference_cpp`, fields, precision_int, zone, nonexistent_string, ambiguous_string, reference)
+as_zoned_sys_time_from_naive_time_with_reference_cpp <- function(fields, precision_int, zone, nonexistent_string, ambiguous_string, reference_fields) {
+  .Call(`_clock_as_zoned_sys_time_from_naive_time_with_reference_cpp`, fields, precision_int, zone, nonexistent_string, ambiguous_string, reference_fields)
 }
 
 to_sys_duration_fields_from_sys_seconds_cpp <- function(seconds) {

--- a/R/date.R
+++ b/R/date.R
@@ -114,7 +114,7 @@ as.Date.clock_calendar <- function(x, ...) {
 as.Date.clock_time_point <- function(x, ...) {
   names <- clock_rcrd_names(x)
   x <- time_point_floor(x, "day")
-  x <- field_ticks(x)
+  x <- as_duration(x)
   x <- as.double(x)
   names(x) <- names
   new_date(x)

--- a/R/duration.R
+++ b/R/duration.R
@@ -1150,21 +1150,3 @@ duration_precision <- function(x) {
 duration_precision_attribute <- function(x) {
   attr(x, "precision", exact = TRUE)
 }
-
-# ------------------------------------------------------------------------------
-
-field_ticks <- function(x) {
-  # The `ticks` field is the first field of every
-  # duration / time point / zoned time type, which makes it the field that
-  # names are on. When extracting the field, we don't ever
-  # want the names to come with it.
-  out <- field(x, "ticks")
-  names(out) <- NULL
-  out
-}
-field_ticks_of_day <- function(x) {
-  field(x, "ticks_of_day")
-}
-field_ticks_of_second <- function(x) {
-  field(x, "ticks_of_second")
-}

--- a/src/calendar.h
+++ b/src/calendar.h
@@ -91,9 +91,10 @@ static
 inline
 cpp11::writable::list
 as_sys_time_from_calendar_impl(const Calendar& x) {
+  using Duration = typename ClockDuration::chrono_duration;
+
   const r_ssize size = x.size();
   ClockDuration out(size);
-  using Duration = typename ClockDuration::duration;
 
   for (r_ssize i = 0; i < size; ++i) {
     if (x.is_na(i)) {
@@ -108,12 +109,15 @@ as_sys_time_from_calendar_impl(const Calendar& x) {
   return out.to_list();
 }
 
-template <class Calendar, class ClockDuration>
+template <class ClockDuration, class Calendar>
 cpp11::writable::list
-as_calendar_from_sys_time_impl(const ClockDuration& x) {
+as_calendar_from_sys_time_impl(cpp11::list_of<cpp11::doubles>& fields) {
+  using Duration = typename ClockDuration::chrono_duration;
+
+  const ClockDuration x{fields};
   const r_ssize size = x.size();
+
   Calendar out(size);
-  using Duration = typename ClockDuration::duration;
 
   for (r_ssize i = 0; i < size; ++i) {
     if (x.is_na(i)) {

--- a/src/cpp11.cpp
+++ b/src/cpp11.cpp
@@ -20,73 +20,73 @@ extern "C" SEXP _clock_duration_restore(SEXP x, SEXP to) {
   END_CPP11
 }
 // duration.cpp
-cpp11::writable::strings format_duration_cpp(cpp11::list_of<cpp11::integers> fields, const cpp11::integers& precision_int);
+cpp11::writable::strings format_duration_cpp(cpp11::list_of<cpp11::doubles> fields, const cpp11::integers& precision_int);
 extern "C" SEXP _clock_format_duration_cpp(SEXP fields, SEXP precision_int) {
   BEGIN_CPP11
-    return cpp11::as_sexp(format_duration_cpp(cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::integers>>>(fields), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(precision_int)));
+    return cpp11::as_sexp(format_duration_cpp(cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::doubles>>>(fields), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(precision_int)));
   END_CPP11
 }
 // duration.cpp
-cpp11::writable::list_of<cpp11::writable::integers> duration_helper_cpp(const cpp11::integers& n, const cpp11::integers& precision_int);
+cpp11::writable::list_of<cpp11::writable::doubles> duration_helper_cpp(const cpp11::integers& n, const cpp11::integers& precision_int);
 extern "C" SEXP _clock_duration_helper_cpp(SEXP n, SEXP precision_int) {
   BEGIN_CPP11
     return cpp11::as_sexp(duration_helper_cpp(cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(n), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(precision_int)));
   END_CPP11
 }
 // duration.cpp
-cpp11::writable::list duration_cast_cpp(cpp11::list_of<cpp11::integers> fields, const cpp11::integers& precision_from, const cpp11::integers& precision_to);
+cpp11::writable::list duration_cast_cpp(cpp11::list_of<cpp11::doubles> fields, const cpp11::integers& precision_from, const cpp11::integers& precision_to);
 extern "C" SEXP _clock_duration_cast_cpp(SEXP fields, SEXP precision_from, SEXP precision_to) {
   BEGIN_CPP11
-    return cpp11::as_sexp(duration_cast_cpp(cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::integers>>>(fields), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(precision_from), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(precision_to)));
+    return cpp11::as_sexp(duration_cast_cpp(cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::doubles>>>(fields), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(precision_from), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(precision_to)));
   END_CPP11
 }
 // duration.cpp
-cpp11::writable::list duration_plus_cpp(cpp11::list_of<cpp11::integers> x, cpp11::list_of<cpp11::integers> y, const cpp11::integers& precision_int);
+cpp11::writable::list duration_plus_cpp(cpp11::list_of<cpp11::doubles> x, cpp11::list_of<cpp11::doubles> y, const cpp11::integers& precision_int);
 extern "C" SEXP _clock_duration_plus_cpp(SEXP x, SEXP y, SEXP precision_int) {
   BEGIN_CPP11
-    return cpp11::as_sexp(duration_plus_cpp(cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::integers>>>(x), cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::integers>>>(y), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(precision_int)));
+    return cpp11::as_sexp(duration_plus_cpp(cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::doubles>>>(x), cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::doubles>>>(y), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(precision_int)));
   END_CPP11
 }
 // duration.cpp
-cpp11::writable::list duration_minus_cpp(cpp11::list_of<cpp11::integers> x, cpp11::list_of<cpp11::integers> y, const cpp11::integers& precision_int);
+cpp11::writable::list duration_minus_cpp(cpp11::list_of<cpp11::doubles> x, cpp11::list_of<cpp11::doubles> y, const cpp11::integers& precision_int);
 extern "C" SEXP _clock_duration_minus_cpp(SEXP x, SEXP y, SEXP precision_int) {
   BEGIN_CPP11
-    return cpp11::as_sexp(duration_minus_cpp(cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::integers>>>(x), cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::integers>>>(y), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(precision_int)));
+    return cpp11::as_sexp(duration_minus_cpp(cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::doubles>>>(x), cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::doubles>>>(y), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(precision_int)));
   END_CPP11
 }
 // duration.cpp
-cpp11::writable::list duration_modulus_cpp(cpp11::list_of<cpp11::integers> x, cpp11::list_of<cpp11::integers> y, const cpp11::integers& precision_int);
+cpp11::writable::list duration_modulus_cpp(cpp11::list_of<cpp11::doubles> x, cpp11::list_of<cpp11::doubles> y, const cpp11::integers& precision_int);
 extern "C" SEXP _clock_duration_modulus_cpp(SEXP x, SEXP y, SEXP precision_int) {
   BEGIN_CPP11
-    return cpp11::as_sexp(duration_modulus_cpp(cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::integers>>>(x), cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::integers>>>(y), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(precision_int)));
+    return cpp11::as_sexp(duration_modulus_cpp(cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::doubles>>>(x), cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::doubles>>>(y), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(precision_int)));
   END_CPP11
 }
 // duration.cpp
-cpp11::writable::integers duration_integer_divide_cpp(cpp11::list_of<cpp11::integers> x, cpp11::list_of<cpp11::integers> y, const cpp11::integers& precision_int);
+cpp11::writable::integers duration_integer_divide_cpp(cpp11::list_of<cpp11::doubles> x, cpp11::list_of<cpp11::doubles> y, const cpp11::integers& precision_int);
 extern "C" SEXP _clock_duration_integer_divide_cpp(SEXP x, SEXP y, SEXP precision_int) {
   BEGIN_CPP11
-    return cpp11::as_sexp(duration_integer_divide_cpp(cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::integers>>>(x), cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::integers>>>(y), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(precision_int)));
+    return cpp11::as_sexp(duration_integer_divide_cpp(cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::doubles>>>(x), cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::doubles>>>(y), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(precision_int)));
   END_CPP11
 }
 // duration.cpp
-cpp11::writable::list duration_scalar_multiply_cpp(cpp11::list_of<cpp11::integers> x, const cpp11::integers& y, const cpp11::integers& precision_int);
+cpp11::writable::list duration_scalar_multiply_cpp(cpp11::list_of<cpp11::doubles> x, const cpp11::integers& y, const cpp11::integers& precision_int);
 extern "C" SEXP _clock_duration_scalar_multiply_cpp(SEXP x, SEXP y, SEXP precision_int) {
   BEGIN_CPP11
-    return cpp11::as_sexp(duration_scalar_multiply_cpp(cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::integers>>>(x), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(y), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(precision_int)));
+    return cpp11::as_sexp(duration_scalar_multiply_cpp(cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::doubles>>>(x), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(y), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(precision_int)));
   END_CPP11
 }
 // duration.cpp
-cpp11::writable::list duration_scalar_modulus_cpp(cpp11::list_of<cpp11::integers> x, const cpp11::integers& y, const cpp11::integers& precision_int);
+cpp11::writable::list duration_scalar_modulus_cpp(cpp11::list_of<cpp11::doubles> x, const cpp11::integers& y, const cpp11::integers& precision_int);
 extern "C" SEXP _clock_duration_scalar_modulus_cpp(SEXP x, SEXP y, SEXP precision_int) {
   BEGIN_CPP11
-    return cpp11::as_sexp(duration_scalar_modulus_cpp(cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::integers>>>(x), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(y), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(precision_int)));
+    return cpp11::as_sexp(duration_scalar_modulus_cpp(cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::doubles>>>(x), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(y), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(precision_int)));
   END_CPP11
 }
 // duration.cpp
-cpp11::writable::list duration_scalar_divide_cpp(cpp11::list_of<cpp11::integers> x, const cpp11::integers& y, const cpp11::integers& precision_int);
+cpp11::writable::list duration_scalar_divide_cpp(cpp11::list_of<cpp11::doubles> x, const cpp11::integers& y, const cpp11::integers& precision_int);
 extern "C" SEXP _clock_duration_scalar_divide_cpp(SEXP x, SEXP y, SEXP precision_int) {
   BEGIN_CPP11
-    return cpp11::as_sexp(duration_scalar_divide_cpp(cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::integers>>>(x), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(y), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(precision_int)));
+    return cpp11::as_sexp(duration_scalar_divide_cpp(cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::doubles>>>(x), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(y), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(precision_int)));
   END_CPP11
 }
 // duration.cpp
@@ -104,80 +104,80 @@ extern "C" SEXP _clock_duration_has_common_precision_cpp(SEXP x_precision, SEXP 
   END_CPP11
 }
 // duration.cpp
-cpp11::writable::list duration_floor_cpp(cpp11::list_of<cpp11::integers> fields, const cpp11::integers& precision_from, const cpp11::integers& precision_to, const int& n);
+cpp11::writable::list duration_floor_cpp(cpp11::list_of<cpp11::doubles> fields, const cpp11::integers& precision_from, const cpp11::integers& precision_to, const int& n);
 extern "C" SEXP _clock_duration_floor_cpp(SEXP fields, SEXP precision_from, SEXP precision_to, SEXP n) {
   BEGIN_CPP11
-    return cpp11::as_sexp(duration_floor_cpp(cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::integers>>>(fields), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(precision_from), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(precision_to), cpp11::as_cpp<cpp11::decay_t<const int&>>(n)));
+    return cpp11::as_sexp(duration_floor_cpp(cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::doubles>>>(fields), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(precision_from), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(precision_to), cpp11::as_cpp<cpp11::decay_t<const int&>>(n)));
   END_CPP11
 }
 // duration.cpp
-cpp11::writable::list duration_ceiling_cpp(cpp11::list_of<cpp11::integers> fields, const cpp11::integers& precision_from, const cpp11::integers& precision_to, const int& n);
+cpp11::writable::list duration_ceiling_cpp(cpp11::list_of<cpp11::doubles> fields, const cpp11::integers& precision_from, const cpp11::integers& precision_to, const int& n);
 extern "C" SEXP _clock_duration_ceiling_cpp(SEXP fields, SEXP precision_from, SEXP precision_to, SEXP n) {
   BEGIN_CPP11
-    return cpp11::as_sexp(duration_ceiling_cpp(cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::integers>>>(fields), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(precision_from), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(precision_to), cpp11::as_cpp<cpp11::decay_t<const int&>>(n)));
+    return cpp11::as_sexp(duration_ceiling_cpp(cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::doubles>>>(fields), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(precision_from), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(precision_to), cpp11::as_cpp<cpp11::decay_t<const int&>>(n)));
   END_CPP11
 }
 // duration.cpp
-cpp11::writable::list duration_round_cpp(cpp11::list_of<cpp11::integers> fields, const cpp11::integers& precision_from, const cpp11::integers& precision_to, const int& n);
+cpp11::writable::list duration_round_cpp(cpp11::list_of<cpp11::doubles> fields, const cpp11::integers& precision_from, const cpp11::integers& precision_to, const int& n);
 extern "C" SEXP _clock_duration_round_cpp(SEXP fields, SEXP precision_from, SEXP precision_to, SEXP n) {
   BEGIN_CPP11
-    return cpp11::as_sexp(duration_round_cpp(cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::integers>>>(fields), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(precision_from), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(precision_to), cpp11::as_cpp<cpp11::decay_t<const int&>>(n)));
+    return cpp11::as_sexp(duration_round_cpp(cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::doubles>>>(fields), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(precision_from), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(precision_to), cpp11::as_cpp<cpp11::decay_t<const int&>>(n)));
   END_CPP11
 }
 // duration.cpp
-cpp11::writable::list duration_unary_minus_cpp(cpp11::list_of<cpp11::integers> fields, const cpp11::integers& precision_int);
+cpp11::writable::list duration_unary_minus_cpp(cpp11::list_of<cpp11::doubles> fields, const cpp11::integers& precision_int);
 extern "C" SEXP _clock_duration_unary_minus_cpp(SEXP fields, SEXP precision_int) {
   BEGIN_CPP11
-    return cpp11::as_sexp(duration_unary_minus_cpp(cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::integers>>>(fields), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(precision_int)));
+    return cpp11::as_sexp(duration_unary_minus_cpp(cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::doubles>>>(fields), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(precision_int)));
   END_CPP11
 }
 // duration.cpp
-cpp11::writable::integers duration_as_integer_cpp(cpp11::list_of<cpp11::integers> fields, const cpp11::integers& precision_int);
+cpp11::writable::integers duration_as_integer_cpp(cpp11::list_of<cpp11::doubles> fields, const cpp11::integers& precision_int);
 extern "C" SEXP _clock_duration_as_integer_cpp(SEXP fields, SEXP precision_int) {
   BEGIN_CPP11
-    return cpp11::as_sexp(duration_as_integer_cpp(cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::integers>>>(fields), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(precision_int)));
+    return cpp11::as_sexp(duration_as_integer_cpp(cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::doubles>>>(fields), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(precision_int)));
   END_CPP11
 }
 // duration.cpp
-cpp11::writable::doubles duration_as_double_cpp(cpp11::list_of<cpp11::integers> fields, const cpp11::integers& precision_int);
+cpp11::writable::doubles duration_as_double_cpp(cpp11::list_of<cpp11::doubles> fields, const cpp11::integers& precision_int);
 extern "C" SEXP _clock_duration_as_double_cpp(SEXP fields, SEXP precision_int) {
   BEGIN_CPP11
-    return cpp11::as_sexp(duration_as_double_cpp(cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::integers>>>(fields), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(precision_int)));
+    return cpp11::as_sexp(duration_as_double_cpp(cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::doubles>>>(fields), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(precision_int)));
   END_CPP11
 }
 // duration.cpp
-cpp11::writable::list duration_abs_cpp(cpp11::list_of<cpp11::integers> fields, const cpp11::integers& precision_int);
+cpp11::writable::list duration_abs_cpp(cpp11::list_of<cpp11::doubles> fields, const cpp11::integers& precision_int);
 extern "C" SEXP _clock_duration_abs_cpp(SEXP fields, SEXP precision_int) {
   BEGIN_CPP11
-    return cpp11::as_sexp(duration_abs_cpp(cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::integers>>>(fields), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(precision_int)));
+    return cpp11::as_sexp(duration_abs_cpp(cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::doubles>>>(fields), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(precision_int)));
   END_CPP11
 }
 // duration.cpp
-cpp11::writable::integers duration_sign_cpp(cpp11::list_of<cpp11::integers> fields, const cpp11::integers& precision_int);
+cpp11::writable::integers duration_sign_cpp(cpp11::list_of<cpp11::doubles> fields, const cpp11::integers& precision_int);
 extern "C" SEXP _clock_duration_sign_cpp(SEXP fields, SEXP precision_int) {
   BEGIN_CPP11
-    return cpp11::as_sexp(duration_sign_cpp(cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::integers>>>(fields), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(precision_int)));
+    return cpp11::as_sexp(duration_sign_cpp(cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::doubles>>>(fields), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(precision_int)));
   END_CPP11
 }
 // duration.cpp
-cpp11::writable::list duration_seq_by_lo_cpp(cpp11::list_of<cpp11::integers> from, const cpp11::integers& precision_int, cpp11::list_of<cpp11::integers> by, const cpp11::integers& length_out);
+cpp11::writable::list duration_seq_by_lo_cpp(cpp11::list_of<cpp11::doubles> from, const cpp11::integers& precision_int, cpp11::list_of<cpp11::doubles> by, const cpp11::integers& length_out);
 extern "C" SEXP _clock_duration_seq_by_lo_cpp(SEXP from, SEXP precision_int, SEXP by, SEXP length_out) {
   BEGIN_CPP11
-    return cpp11::as_sexp(duration_seq_by_lo_cpp(cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::integers>>>(from), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(precision_int), cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::integers>>>(by), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(length_out)));
+    return cpp11::as_sexp(duration_seq_by_lo_cpp(cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::doubles>>>(from), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(precision_int), cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::doubles>>>(by), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(length_out)));
   END_CPP11
 }
 // duration.cpp
-cpp11::writable::list duration_seq_to_by_cpp(cpp11::list_of<cpp11::integers> from, const cpp11::integers& precision_int, cpp11::list_of<cpp11::integers> to, cpp11::list_of<cpp11::integers> by);
+cpp11::writable::list duration_seq_to_by_cpp(cpp11::list_of<cpp11::doubles> from, const cpp11::integers& precision_int, cpp11::list_of<cpp11::doubles> to, cpp11::list_of<cpp11::doubles> by);
 extern "C" SEXP _clock_duration_seq_to_by_cpp(SEXP from, SEXP precision_int, SEXP to, SEXP by) {
   BEGIN_CPP11
-    return cpp11::as_sexp(duration_seq_to_by_cpp(cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::integers>>>(from), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(precision_int), cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::integers>>>(to), cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::integers>>>(by)));
+    return cpp11::as_sexp(duration_seq_to_by_cpp(cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::doubles>>>(from), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(precision_int), cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::doubles>>>(to), cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::doubles>>>(by)));
   END_CPP11
 }
 // duration.cpp
-cpp11::writable::list duration_seq_to_lo_cpp(cpp11::list_of<cpp11::integers> from, const cpp11::integers& precision_int, cpp11::list_of<cpp11::integers> to, const cpp11::integers& length_out);
+cpp11::writable::list duration_seq_to_lo_cpp(cpp11::list_of<cpp11::doubles> from, const cpp11::integers& precision_int, cpp11::list_of<cpp11::doubles> to, const cpp11::integers& length_out);
 extern "C" SEXP _clock_duration_seq_to_lo_cpp(SEXP from, SEXP precision_int, SEXP to, SEXP length_out) {
   BEGIN_CPP11
-    return cpp11::as_sexp(duration_seq_to_lo_cpp(cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::integers>>>(from), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(precision_int), cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::integers>>>(to), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(length_out)));
+    return cpp11::as_sexp(duration_seq_to_lo_cpp(cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::doubles>>>(from), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(precision_int), cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::doubles>>>(to), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(length_out)));
   END_CPP11
 }
 // enums.cpp
@@ -195,17 +195,17 @@ extern "C" SEXP _clock_clock_to_string(SEXP clock_int) {
   END_CPP11
 }
 // format.cpp
-cpp11::writable::strings format_time_point_cpp(cpp11::list_of<cpp11::integers> fields, const cpp11::integers& clock, const cpp11::strings& format, const cpp11::integers& precision_int, const cpp11::strings& month, const cpp11::strings& month_abbrev, const cpp11::strings& weekday, const cpp11::strings& weekday_abbrev, const cpp11::strings& am_pm, const cpp11::strings& decimal_mark);
+cpp11::writable::strings format_time_point_cpp(cpp11::list_of<cpp11::doubles> fields, const cpp11::integers& clock, const cpp11::strings& format, const cpp11::integers& precision_int, const cpp11::strings& month, const cpp11::strings& month_abbrev, const cpp11::strings& weekday, const cpp11::strings& weekday_abbrev, const cpp11::strings& am_pm, const cpp11::strings& decimal_mark);
 extern "C" SEXP _clock_format_time_point_cpp(SEXP fields, SEXP clock, SEXP format, SEXP precision_int, SEXP month, SEXP month_abbrev, SEXP weekday, SEXP weekday_abbrev, SEXP am_pm, SEXP decimal_mark) {
   BEGIN_CPP11
-    return cpp11::as_sexp(format_time_point_cpp(cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::integers>>>(fields), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(clock), cpp11::as_cpp<cpp11::decay_t<const cpp11::strings&>>(format), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(precision_int), cpp11::as_cpp<cpp11::decay_t<const cpp11::strings&>>(month), cpp11::as_cpp<cpp11::decay_t<const cpp11::strings&>>(month_abbrev), cpp11::as_cpp<cpp11::decay_t<const cpp11::strings&>>(weekday), cpp11::as_cpp<cpp11::decay_t<const cpp11::strings&>>(weekday_abbrev), cpp11::as_cpp<cpp11::decay_t<const cpp11::strings&>>(am_pm), cpp11::as_cpp<cpp11::decay_t<const cpp11::strings&>>(decimal_mark)));
+    return cpp11::as_sexp(format_time_point_cpp(cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::doubles>>>(fields), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(clock), cpp11::as_cpp<cpp11::decay_t<const cpp11::strings&>>(format), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(precision_int), cpp11::as_cpp<cpp11::decay_t<const cpp11::strings&>>(month), cpp11::as_cpp<cpp11::decay_t<const cpp11::strings&>>(month_abbrev), cpp11::as_cpp<cpp11::decay_t<const cpp11::strings&>>(weekday), cpp11::as_cpp<cpp11::decay_t<const cpp11::strings&>>(weekday_abbrev), cpp11::as_cpp<cpp11::decay_t<const cpp11::strings&>>(am_pm), cpp11::as_cpp<cpp11::decay_t<const cpp11::strings&>>(decimal_mark)));
   END_CPP11
 }
 // format.cpp
-cpp11::writable::strings format_zoned_time_cpp(cpp11::list_of<cpp11::integers> fields, const cpp11::strings& zone, const bool& abbreviate_zone, const cpp11::strings& format, const cpp11::integers& precision_int, const cpp11::strings& month, const cpp11::strings& month_abbrev, const cpp11::strings& weekday, const cpp11::strings& weekday_abbrev, const cpp11::strings& am_pm, const cpp11::strings& decimal_mark);
+cpp11::writable::strings format_zoned_time_cpp(cpp11::list_of<cpp11::doubles> fields, const cpp11::strings& zone, const bool& abbreviate_zone, const cpp11::strings& format, const cpp11::integers& precision_int, const cpp11::strings& month, const cpp11::strings& month_abbrev, const cpp11::strings& weekday, const cpp11::strings& weekday_abbrev, const cpp11::strings& am_pm, const cpp11::strings& decimal_mark);
 extern "C" SEXP _clock_format_zoned_time_cpp(SEXP fields, SEXP zone, SEXP abbreviate_zone, SEXP format, SEXP precision_int, SEXP month, SEXP month_abbrev, SEXP weekday, SEXP weekday_abbrev, SEXP am_pm, SEXP decimal_mark) {
   BEGIN_CPP11
-    return cpp11::as_sexp(format_zoned_time_cpp(cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::integers>>>(fields), cpp11::as_cpp<cpp11::decay_t<const cpp11::strings&>>(zone), cpp11::as_cpp<cpp11::decay_t<const bool&>>(abbreviate_zone), cpp11::as_cpp<cpp11::decay_t<const cpp11::strings&>>(format), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(precision_int), cpp11::as_cpp<cpp11::decay_t<const cpp11::strings&>>(month), cpp11::as_cpp<cpp11::decay_t<const cpp11::strings&>>(month_abbrev), cpp11::as_cpp<cpp11::decay_t<const cpp11::strings&>>(weekday), cpp11::as_cpp<cpp11::decay_t<const cpp11::strings&>>(weekday_abbrev), cpp11::as_cpp<cpp11::decay_t<const cpp11::strings&>>(am_pm), cpp11::as_cpp<cpp11::decay_t<const cpp11::strings&>>(decimal_mark)));
+    return cpp11::as_sexp(format_zoned_time_cpp(cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::doubles>>>(fields), cpp11::as_cpp<cpp11::decay_t<const cpp11::strings&>>(zone), cpp11::as_cpp<cpp11::decay_t<const bool&>>(abbreviate_zone), cpp11::as_cpp<cpp11::decay_t<const cpp11::strings&>>(format), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(precision_int), cpp11::as_cpp<cpp11::decay_t<const cpp11::strings&>>(month), cpp11::as_cpp<cpp11::decay_t<const cpp11::strings&>>(month_abbrev), cpp11::as_cpp<cpp11::decay_t<const cpp11::strings&>>(weekday), cpp11::as_cpp<cpp11::decay_t<const cpp11::strings&>>(weekday_abbrev), cpp11::as_cpp<cpp11::decay_t<const cpp11::strings&>>(am_pm), cpp11::as_cpp<cpp11::decay_t<const cpp11::strings&>>(decimal_mark)));
   END_CPP11
 }
 // gregorian-year-day.cpp
@@ -265,10 +265,10 @@ extern "C" SEXP _clock_get_year_day_last_cpp(SEXP year) {
   END_CPP11
 }
 // gregorian-year-day.cpp
-cpp11::writable::list year_day_plus_duration_cpp(cpp11::list_of<cpp11::integers> fields, cpp11::list_of<cpp11::integers> fields_n, const cpp11::integers& precision_fields, const cpp11::integers& precision_n);
+cpp11::writable::list year_day_plus_duration_cpp(cpp11::list_of<cpp11::integers> fields, cpp11::list_of<cpp11::doubles> fields_n, const cpp11::integers& precision_fields, const cpp11::integers& precision_n);
 extern "C" SEXP _clock_year_day_plus_duration_cpp(SEXP fields, SEXP fields_n, SEXP precision_fields, SEXP precision_n) {
   BEGIN_CPP11
-    return cpp11::as_sexp(year_day_plus_duration_cpp(cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::integers>>>(fields), cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::integers>>>(fields_n), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(precision_fields), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(precision_n)));
+    return cpp11::as_sexp(year_day_plus_duration_cpp(cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::integers>>>(fields), cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::doubles>>>(fields_n), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(precision_fields), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(precision_n)));
   END_CPP11
 }
 // gregorian-year-day.cpp
@@ -279,10 +279,10 @@ extern "C" SEXP _clock_as_sys_time_year_day_cpp(SEXP fields, SEXP precision_int)
   END_CPP11
 }
 // gregorian-year-day.cpp
-cpp11::writable::list as_year_day_from_sys_time_cpp(cpp11::list_of<cpp11::integers> fields, const cpp11::integers& precision_int);
+cpp11::writable::list as_year_day_from_sys_time_cpp(cpp11::list_of<cpp11::doubles> fields, const cpp11::integers& precision_int);
 extern "C" SEXP _clock_as_year_day_from_sys_time_cpp(SEXP fields, SEXP precision_int) {
   BEGIN_CPP11
-    return cpp11::as_sexp(as_year_day_from_sys_time_cpp(cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::integers>>>(fields), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(precision_int)));
+    return cpp11::as_sexp(as_year_day_from_sys_time_cpp(cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::doubles>>>(fields), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(precision_int)));
   END_CPP11
 }
 // gregorian-year-day.cpp
@@ -349,10 +349,10 @@ extern "C" SEXP _clock_get_year_month_day_last_cpp(SEXP year, SEXP month) {
   END_CPP11
 }
 // gregorian-year-month-day.cpp
-cpp11::writable::list year_month_day_plus_duration_cpp(cpp11::list_of<cpp11::integers> fields, cpp11::list_of<cpp11::integers> fields_n, const cpp11::integers& precision_fields, const cpp11::integers& precision_n);
+cpp11::writable::list year_month_day_plus_duration_cpp(cpp11::list_of<cpp11::integers> fields, cpp11::list_of<cpp11::doubles> fields_n, const cpp11::integers& precision_fields, const cpp11::integers& precision_n);
 extern "C" SEXP _clock_year_month_day_plus_duration_cpp(SEXP fields, SEXP fields_n, SEXP precision_fields, SEXP precision_n) {
   BEGIN_CPP11
-    return cpp11::as_sexp(year_month_day_plus_duration_cpp(cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::integers>>>(fields), cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::integers>>>(fields_n), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(precision_fields), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(precision_n)));
+    return cpp11::as_sexp(year_month_day_plus_duration_cpp(cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::integers>>>(fields), cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::doubles>>>(fields_n), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(precision_fields), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(precision_n)));
   END_CPP11
 }
 // gregorian-year-month-day.cpp
@@ -363,10 +363,10 @@ extern "C" SEXP _clock_as_sys_time_year_month_day_cpp(SEXP fields, SEXP precisio
   END_CPP11
 }
 // gregorian-year-month-day.cpp
-cpp11::writable::list as_year_month_day_from_sys_time_cpp(cpp11::list_of<cpp11::integers> fields, const cpp11::integers& precision_int);
+cpp11::writable::list as_year_month_day_from_sys_time_cpp(cpp11::list_of<cpp11::doubles> fields, const cpp11::integers& precision_int);
 extern "C" SEXP _clock_as_year_month_day_from_sys_time_cpp(SEXP fields, SEXP precision_int) {
   BEGIN_CPP11
-    return cpp11::as_sexp(as_year_month_day_from_sys_time_cpp(cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::integers>>>(fields), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(precision_int)));
+    return cpp11::as_sexp(as_year_month_day_from_sys_time_cpp(cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::doubles>>>(fields), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(precision_int)));
   END_CPP11
 }
 // gregorian-year-month-day.cpp
@@ -447,10 +447,10 @@ extern "C" SEXP _clock_get_year_month_weekday_last_cpp(SEXP year, SEXP month, SE
   END_CPP11
 }
 // gregorian-year-month-weekday.cpp
-cpp11::writable::list year_month_weekday_plus_duration_cpp(cpp11::list_of<cpp11::integers> fields, cpp11::list_of<cpp11::integers> fields_n, const cpp11::integers& precision_fields, const cpp11::integers& precision_n);
+cpp11::writable::list year_month_weekday_plus_duration_cpp(cpp11::list_of<cpp11::integers> fields, cpp11::list_of<cpp11::doubles> fields_n, const cpp11::integers& precision_fields, const cpp11::integers& precision_n);
 extern "C" SEXP _clock_year_month_weekday_plus_duration_cpp(SEXP fields, SEXP fields_n, SEXP precision_fields, SEXP precision_n) {
   BEGIN_CPP11
-    return cpp11::as_sexp(year_month_weekday_plus_duration_cpp(cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::integers>>>(fields), cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::integers>>>(fields_n), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(precision_fields), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(precision_n)));
+    return cpp11::as_sexp(year_month_weekday_plus_duration_cpp(cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::integers>>>(fields), cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::doubles>>>(fields_n), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(precision_fields), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(precision_n)));
   END_CPP11
 }
 // gregorian-year-month-weekday.cpp
@@ -461,10 +461,10 @@ extern "C" SEXP _clock_as_sys_time_year_month_weekday_cpp(SEXP fields, SEXP prec
   END_CPP11
 }
 // gregorian-year-month-weekday.cpp
-cpp11::writable::list as_year_month_weekday_from_sys_time_cpp(cpp11::list_of<cpp11::integers> fields, const cpp11::integers& precision_int);
+cpp11::writable::list as_year_month_weekday_from_sys_time_cpp(cpp11::list_of<cpp11::doubles> fields, const cpp11::integers& precision_int);
 extern "C" SEXP _clock_as_year_month_weekday_from_sys_time_cpp(SEXP fields, SEXP precision_int) {
   BEGIN_CPP11
-    return cpp11::as_sexp(as_year_month_weekday_from_sys_time_cpp(cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::integers>>>(fields), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(precision_int)));
+    return cpp11::as_sexp(as_year_month_weekday_from_sys_time_cpp(cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::doubles>>>(fields), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(precision_int)));
   END_CPP11
 }
 // gregorian-year-month-weekday.cpp
@@ -531,10 +531,10 @@ extern "C" SEXP _clock_get_iso_year_week_day_last_cpp(SEXP year) {
   END_CPP11
 }
 // iso-year-week-day.cpp
-cpp11::writable::list iso_year_week_day_plus_duration_cpp(cpp11::list_of<cpp11::integers> fields, cpp11::list_of<cpp11::integers> fields_n, const cpp11::integers& precision_fields, const cpp11::integers& precision_n);
+cpp11::writable::list iso_year_week_day_plus_duration_cpp(cpp11::list_of<cpp11::integers> fields, cpp11::list_of<cpp11::doubles> fields_n, const cpp11::integers& precision_fields, const cpp11::integers& precision_n);
 extern "C" SEXP _clock_iso_year_week_day_plus_duration_cpp(SEXP fields, SEXP fields_n, SEXP precision_fields, SEXP precision_n) {
   BEGIN_CPP11
-    return cpp11::as_sexp(iso_year_week_day_plus_duration_cpp(cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::integers>>>(fields), cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::integers>>>(fields_n), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(precision_fields), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(precision_n)));
+    return cpp11::as_sexp(iso_year_week_day_plus_duration_cpp(cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::integers>>>(fields), cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::doubles>>>(fields_n), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(precision_fields), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(precision_n)));
   END_CPP11
 }
 // iso-year-week-day.cpp
@@ -545,10 +545,10 @@ extern "C" SEXP _clock_as_sys_time_iso_year_week_day_cpp(SEXP fields, SEXP preci
   END_CPP11
 }
 // iso-year-week-day.cpp
-cpp11::writable::list as_iso_year_week_day_from_sys_time_cpp(cpp11::list_of<cpp11::integers> fields, const cpp11::integers& precision_int);
+cpp11::writable::list as_iso_year_week_day_from_sys_time_cpp(cpp11::list_of<cpp11::doubles> fields, const cpp11::integers& precision_int);
 extern "C" SEXP _clock_as_iso_year_week_day_from_sys_time_cpp(SEXP fields, SEXP precision_int) {
   BEGIN_CPP11
-    return cpp11::as_sexp(as_iso_year_week_day_from_sys_time_cpp(cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::integers>>>(fields), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(precision_int)));
+    return cpp11::as_sexp(as_iso_year_week_day_from_sys_time_cpp(cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::doubles>>>(fields), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(precision_int)));
   END_CPP11
 }
 // iso-year-week-day.cpp
@@ -573,10 +573,10 @@ extern "C" SEXP _clock_clock_get_year_min() {
   END_CPP11
 }
 // naive-time.cpp
-cpp11::writable::list naive_time_info_cpp(cpp11::list_of<cpp11::integers> fields, const cpp11::integers& precision_int, const cpp11::strings& zone);
+cpp11::writable::list naive_time_info_cpp(cpp11::list_of<cpp11::doubles> fields, const cpp11::integers& precision_int, const cpp11::strings& zone);
 extern "C" SEXP _clock_naive_time_info_cpp(SEXP fields, SEXP precision_int, SEXP zone) {
   BEGIN_CPP11
-    return cpp11::as_sexp(naive_time_info_cpp(cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::integers>>>(fields), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(precision_int), cpp11::as_cpp<cpp11::decay_t<const cpp11::strings&>>(zone)));
+    return cpp11::as_sexp(naive_time_info_cpp(cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::doubles>>>(fields), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(precision_int), cpp11::as_cpp<cpp11::decay_t<const cpp11::strings&>>(zone)));
   END_CPP11
 }
 // quarterly-year-quarter-day.cpp
@@ -636,10 +636,10 @@ extern "C" SEXP _clock_get_year_quarter_day_last_cpp(SEXP year, SEXP quarter, SE
   END_CPP11
 }
 // quarterly-year-quarter-day.cpp
-cpp11::writable::list year_quarter_day_plus_duration_cpp(cpp11::list_of<cpp11::integers> fields, cpp11::list_of<cpp11::integers> fields_n, const cpp11::integers& precision_fields, const cpp11::integers& precision_n, const cpp11::integers& start_int);
+cpp11::writable::list year_quarter_day_plus_duration_cpp(cpp11::list_of<cpp11::integers> fields, cpp11::list_of<cpp11::doubles> fields_n, const cpp11::integers& precision_fields, const cpp11::integers& precision_n, const cpp11::integers& start_int);
 extern "C" SEXP _clock_year_quarter_day_plus_duration_cpp(SEXP fields, SEXP fields_n, SEXP precision_fields, SEXP precision_n, SEXP start_int) {
   BEGIN_CPP11
-    return cpp11::as_sexp(year_quarter_day_plus_duration_cpp(cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::integers>>>(fields), cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::integers>>>(fields_n), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(precision_fields), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(precision_n), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(start_int)));
+    return cpp11::as_sexp(year_quarter_day_plus_duration_cpp(cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::integers>>>(fields), cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::doubles>>>(fields_n), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(precision_fields), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(precision_n), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(start_int)));
   END_CPP11
 }
 // quarterly-year-quarter-day.cpp
@@ -650,10 +650,10 @@ extern "C" SEXP _clock_as_sys_time_year_quarter_day_cpp(SEXP fields, SEXP precis
   END_CPP11
 }
 // quarterly-year-quarter-day.cpp
-cpp11::writable::list as_year_quarter_day_from_sys_time_cpp(cpp11::list_of<cpp11::integers> fields, const cpp11::integers& precision_int, const cpp11::integers& start_int);
+cpp11::writable::list as_year_quarter_day_from_sys_time_cpp(cpp11::list_of<cpp11::doubles> fields, const cpp11::integers& precision_int, const cpp11::integers& start_int);
 extern "C" SEXP _clock_as_year_quarter_day_from_sys_time_cpp(SEXP fields, SEXP precision_int, SEXP start_int) {
   BEGIN_CPP11
-    return cpp11::as_sexp(as_year_quarter_day_from_sys_time_cpp(cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::integers>>>(fields), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(precision_int), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(start_int)));
+    return cpp11::as_sexp(as_year_quarter_day_from_sys_time_cpp(cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::doubles>>>(fields), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(precision_int), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(start_int)));
   END_CPP11
 }
 // quarterly-year-quarter-day.cpp
@@ -692,10 +692,10 @@ extern "C" SEXP _clock_sys_time_now_cpp() {
   END_CPP11
 }
 // sys-time.cpp
-cpp11::writable::list sys_time_info_cpp(cpp11::list_of<cpp11::integers> fields, const cpp11::integers& precision_int, const cpp11::strings& zone);
+cpp11::writable::list sys_time_info_cpp(cpp11::list_of<cpp11::doubles> fields, const cpp11::integers& precision_int, const cpp11::strings& zone);
 extern "C" SEXP _clock_sys_time_info_cpp(SEXP fields, SEXP precision_int, SEXP zone) {
   BEGIN_CPP11
-    return cpp11::as_sexp(sys_time_info_cpp(cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::integers>>>(fields), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(precision_int), cpp11::as_cpp<cpp11::decay_t<const cpp11::strings&>>(zone)));
+    return cpp11::as_sexp(sys_time_info_cpp(cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::doubles>>>(fields), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(precision_int), cpp11::as_cpp<cpp11::decay_t<const cpp11::strings&>>(zone)));
   END_CPP11
 }
 // time-point.cpp
@@ -727,10 +727,10 @@ extern "C" SEXP _clock_clock_init_utils() {
   END_CPP11
 }
 // weekday.cpp
-cpp11::writable::integers weekday_add_days_cpp(const cpp11::integers& x, cpp11::list_of<cpp11::integers> n);
-extern "C" SEXP _clock_weekday_add_days_cpp(SEXP x, SEXP n) {
+cpp11::writable::integers weekday_add_days_cpp(const cpp11::integers& x, cpp11::list_of<cpp11::doubles> n_fields);
+extern "C" SEXP _clock_weekday_add_days_cpp(SEXP x, SEXP n_fields) {
   BEGIN_CPP11
-    return cpp11::as_sexp(weekday_add_days_cpp(cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(x), cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::integers>>>(n)));
+    return cpp11::as_sexp(weekday_add_days_cpp(cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(x), cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::doubles>>>(n_fields)));
   END_CPP11
 }
 // weekday.cpp
@@ -741,10 +741,10 @@ extern "C" SEXP _clock_weekday_minus_weekday_cpp(SEXP x, SEXP y) {
   END_CPP11
 }
 // weekday.cpp
-cpp11::writable::integers weekday_from_time_point_cpp(cpp11::list_of<cpp11::integers> x);
-extern "C" SEXP _clock_weekday_from_time_point_cpp(SEXP x) {
+cpp11::writable::integers weekday_from_time_point_cpp(cpp11::list_of<cpp11::doubles> x_fields);
+extern "C" SEXP _clock_weekday_from_time_point_cpp(SEXP x_fields) {
   BEGIN_CPP11
-    return cpp11::as_sexp(weekday_from_time_point_cpp(cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::integers>>>(x)));
+    return cpp11::as_sexp(weekday_from_time_point_cpp(cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::doubles>>>(x_fields)));
   END_CPP11
 }
 // weekday.cpp
@@ -783,24 +783,24 @@ extern "C" SEXP _clock_zoned_time_restore(SEXP x, SEXP to) {
   END_CPP11
 }
 // zoned-time.cpp
-cpp11::writable::list get_naive_time_cpp(cpp11::list_of<cpp11::integers> fields, const cpp11::integers& precision_int, const cpp11::strings& zone);
+cpp11::writable::list get_naive_time_cpp(cpp11::list_of<cpp11::doubles> fields, const cpp11::integers& precision_int, const cpp11::strings& zone);
 extern "C" SEXP _clock_get_naive_time_cpp(SEXP fields, SEXP precision_int, SEXP zone) {
   BEGIN_CPP11
-    return cpp11::as_sexp(get_naive_time_cpp(cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::integers>>>(fields), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(precision_int), cpp11::as_cpp<cpp11::decay_t<const cpp11::strings&>>(zone)));
+    return cpp11::as_sexp(get_naive_time_cpp(cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::doubles>>>(fields), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(precision_int), cpp11::as_cpp<cpp11::decay_t<const cpp11::strings&>>(zone)));
   END_CPP11
 }
 // zoned-time.cpp
-cpp11::writable::list as_zoned_sys_time_from_naive_time_cpp(cpp11::list_of<cpp11::integers> fields, const cpp11::integers& precision_int, const cpp11::strings& zone, const cpp11::strings& nonexistent_string, const cpp11::strings& ambiguous_string);
+cpp11::writable::list as_zoned_sys_time_from_naive_time_cpp(cpp11::list_of<cpp11::doubles> fields, const cpp11::integers& precision_int, const cpp11::strings& zone, const cpp11::strings& nonexistent_string, const cpp11::strings& ambiguous_string);
 extern "C" SEXP _clock_as_zoned_sys_time_from_naive_time_cpp(SEXP fields, SEXP precision_int, SEXP zone, SEXP nonexistent_string, SEXP ambiguous_string) {
   BEGIN_CPP11
-    return cpp11::as_sexp(as_zoned_sys_time_from_naive_time_cpp(cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::integers>>>(fields), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(precision_int), cpp11::as_cpp<cpp11::decay_t<const cpp11::strings&>>(zone), cpp11::as_cpp<cpp11::decay_t<const cpp11::strings&>>(nonexistent_string), cpp11::as_cpp<cpp11::decay_t<const cpp11::strings&>>(ambiguous_string)));
+    return cpp11::as_sexp(as_zoned_sys_time_from_naive_time_cpp(cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::doubles>>>(fields), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(precision_int), cpp11::as_cpp<cpp11::decay_t<const cpp11::strings&>>(zone), cpp11::as_cpp<cpp11::decay_t<const cpp11::strings&>>(nonexistent_string), cpp11::as_cpp<cpp11::decay_t<const cpp11::strings&>>(ambiguous_string)));
   END_CPP11
 }
 // zoned-time.cpp
-cpp11::writable::list as_zoned_sys_time_from_naive_time_with_reference_cpp(cpp11::list_of<cpp11::integers> fields, const cpp11::integers& precision_int, const cpp11::strings& zone, const cpp11::strings& nonexistent_string, const cpp11::strings& ambiguous_string, cpp11::list_of<cpp11::integers> reference);
-extern "C" SEXP _clock_as_zoned_sys_time_from_naive_time_with_reference_cpp(SEXP fields, SEXP precision_int, SEXP zone, SEXP nonexistent_string, SEXP ambiguous_string, SEXP reference) {
+cpp11::writable::list as_zoned_sys_time_from_naive_time_with_reference_cpp(cpp11::list_of<cpp11::doubles> fields, const cpp11::integers& precision_int, const cpp11::strings& zone, const cpp11::strings& nonexistent_string, const cpp11::strings& ambiguous_string, cpp11::list_of<cpp11::doubles> reference_fields);
+extern "C" SEXP _clock_as_zoned_sys_time_from_naive_time_with_reference_cpp(SEXP fields, SEXP precision_int, SEXP zone, SEXP nonexistent_string, SEXP ambiguous_string, SEXP reference_fields) {
   BEGIN_CPP11
-    return cpp11::as_sexp(as_zoned_sys_time_from_naive_time_with_reference_cpp(cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::integers>>>(fields), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(precision_int), cpp11::as_cpp<cpp11::decay_t<const cpp11::strings&>>(zone), cpp11::as_cpp<cpp11::decay_t<const cpp11::strings&>>(nonexistent_string), cpp11::as_cpp<cpp11::decay_t<const cpp11::strings&>>(ambiguous_string), cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::integers>>>(reference)));
+    return cpp11::as_sexp(as_zoned_sys_time_from_naive_time_with_reference_cpp(cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::doubles>>>(fields), cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(precision_int), cpp11::as_cpp<cpp11::decay_t<const cpp11::strings&>>(zone), cpp11::as_cpp<cpp11::decay_t<const cpp11::strings&>>(nonexistent_string), cpp11::as_cpp<cpp11::decay_t<const cpp11::strings&>>(ambiguous_string), cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::doubles>>>(reference_fields)));
   END_CPP11
 }
 // zoned-time.cpp
@@ -811,10 +811,10 @@ extern "C" SEXP _clock_to_sys_duration_fields_from_sys_seconds_cpp(SEXP seconds)
   END_CPP11
 }
 // zoned-time.cpp
-cpp11::writable::doubles to_sys_seconds_from_sys_duration_fields_cpp(cpp11::list_of<cpp11::integers> fields);
+cpp11::writable::doubles to_sys_seconds_from_sys_duration_fields_cpp(cpp11::list_of<cpp11::doubles> fields);
 extern "C" SEXP _clock_to_sys_seconds_from_sys_duration_fields_cpp(SEXP fields) {
   BEGIN_CPP11
-    return cpp11::as_sexp(to_sys_seconds_from_sys_duration_fields_cpp(cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::integers>>>(fields)));
+    return cpp11::as_sexp(to_sys_seconds_from_sys_duration_fields_cpp(cpp11::as_cpp<cpp11::decay_t<cpp11::list_of<cpp11::doubles>>>(fields)));
   END_CPP11
 }
 // zoned-time.cpp

--- a/src/doubles.h
+++ b/src/doubles.h
@@ -1,0 +1,101 @@
+#ifndef CLOCK_DOUBLES_H
+#define CLOCK_DOUBLES_H
+
+#include "clock.h"
+
+namespace rclock {
+
+class doubles
+{
+  const cpp11::doubles read_;
+  cpp11::writable::doubles write_;
+  bool writable_;
+  r_ssize size_;
+
+public:
+  doubles() noexcept;
+  doubles(const cpp11::doubles& x);
+  doubles(r_ssize size);
+
+  bool is_na(r_ssize i) const noexcept;
+  r_ssize size() const noexcept;
+
+  void assign(double x, r_ssize i);
+  void assign_na(r_ssize i);
+
+  double operator[](r_ssize i) const noexcept;
+
+  SEXP sexp() const noexcept;
+};
+
+namespace detail {
+
+static const cpp11::doubles empty_doubles = cpp11::doubles{};
+
+} // namespace detail
+
+inline
+doubles::doubles() noexcept
+  : read_(detail::empty_doubles),
+    writable_(false),
+    size_(0)
+  {}
+
+inline
+doubles::doubles(const cpp11::doubles& x)
+  : read_(x),
+    writable_(false),
+    size_(x.size())
+  {}
+
+inline
+doubles::doubles(r_ssize size)
+  : read_(detail::empty_doubles),
+    write_(cpp11::writable::doubles(size)),
+    writable_(true),
+    size_(size)
+  {}
+
+inline
+bool
+doubles::is_na(r_ssize i) const noexcept {
+  return std::isnan(this->operator[](i));
+}
+
+inline
+r_ssize
+doubles::size() const noexcept {
+  return size_;
+}
+
+inline
+void
+doubles::assign(double x, r_ssize i) {
+  if (!writable_) {
+    write_ = cpp11::writable::doubles(read_);
+    writable_ = true;
+  }
+  write_[i] = x;
+}
+
+inline
+void
+doubles::assign_na(r_ssize i) {
+  return assign(r_dbl_na, i);
+}
+
+inline
+double
+doubles::operator[](r_ssize i) const noexcept {
+  return writable_ ? write_[i] : read_[i];
+}
+
+inline
+SEXP
+doubles::sexp() const noexcept {
+  return writable_ ? write_ : read_;
+}
+
+} // namespace rclock
+
+#endif

--- a/src/duration.h
+++ b/src/duration.h
@@ -2,11 +2,217 @@
 #define CLOCK_DURATION_H
 
 #include "clock.h"
-#include "integers.h"
+#include "doubles.h"
 #include "enums.h"
 #include "utils.h"
 
+#include <limits>
+
 namespace rclock {
+
+namespace duration {
+
+template <typename Duration>
+class duration
+{
+public:
+  CONSTCD11 duration(cpp11::list_of<cpp11::doubles>& fields) NOEXCEPT;
+  duration(r_ssize size);
+
+  CONSTCD11 bool is_na(r_ssize i) const NOEXCEPT;
+  CONSTCD11 r_ssize size() const NOEXCEPT;
+
+  void assign_na(r_ssize i);
+  void assign(const Duration& x, r_ssize i);
+
+  CONSTCD11 Duration operator[](r_ssize i) const NOEXCEPT;
+
+  cpp11::writable::list to_list() const;
+
+  // Only used by `zoned-time.cpp`
+  void convert_local_to_sys_and_assign(const date::local_time<Duration>& x,
+                                       const date::local_info& info,
+                                       const enum nonexistent& nonexistent_val,
+                                       const enum ambiguous& ambiguous_val,
+                                       const r_ssize& i);
+  void convert_local_with_reference_to_sys_and_assign(const date::local_time<Duration>& x,
+                                                      const date::local_info& info,
+                                                      const enum nonexistent& nonexistent_val,
+                                                      const enum ambiguous& ambiguous_val,
+                                                      const date::sys_seconds& reference,
+                                                      const date::time_zone* p_time_zone,
+                                                      const r_ssize& i);
+
+  using chrono_duration = Duration;
+
+protected:
+  rclock::doubles lower_;
+  rclock::doubles upper_;
+};
+
+using years = duration<date::years>;
+using quarters = duration<quarterly::quarters>;
+using months = duration<date::months>;
+using weeks = duration<date::weeks>;
+using days = duration<date::days>;
+using hours = duration<std::chrono::hours>;
+using minutes = duration<std::chrono::minutes>;
+using seconds = duration<std::chrono::seconds>;
+using milliseconds = duration<std::chrono::milliseconds>;
+using microseconds = duration<std::chrono::microseconds>;
+using nanoseconds = duration<std::chrono::nanoseconds>;
+
+// Implementation
+
+namespace detail {
+
+static
+inline
+cpp11::doubles
+get_lower(cpp11::list_of<cpp11::doubles>& fields)
+{
+  return fields[0];
+}
+
+static
+inline
+cpp11::doubles
+get_upper(cpp11::list_of<cpp11::doubles>& fields)
+{
+  return fields[1];
+}
+
+}
+
+template <typename Duration>
+CONSTCD11
+inline
+duration<Duration>::duration(cpp11::list_of<cpp11::doubles>& fields) NOEXCEPT
+  : lower_(detail::get_lower(fields))
+  , upper_(detail::get_upper(fields))
+  {}
+
+template <typename Duration>
+inline
+duration<Duration>::duration(r_ssize size)
+  : lower_(size)
+  , upper_(size)
+  {}
+
+template <typename Duration>
+CONSTCD11
+inline
+bool
+duration<Duration>::is_na(r_ssize i) const NOEXCEPT
+{
+  return lower_.is_na(i);
+}
+
+template <typename Duration>
+CONSTCD11
+inline
+r_ssize
+duration<Duration>::size() const NOEXCEPT
+{
+  return lower_.size();
+}
+
+template <typename Duration>
+inline
+void
+duration<Duration>::assign_na(r_ssize i)
+{
+  lower_.assign_na(i);
+  upper_.assign_na(i);
+}
+
+namespace detail {
+
+/*
+ * This pair of functions facilitates:
+ * - Splitting an `int64_t` into two `uint32_t` values, maintaining order
+ * - Combining those two `uint32_t` values back into the original `int32_t`
+ *
+ * The two `uint32_t` values are stored in two doubles. This allows us to store
+ * it in a two column data frame that vctrs knows how to work with, and we can
+ * use the standard `NA_real_` as the missing value without fear of conflicting
+ * with any other valid `int64_t` value.
+ *
+ * Unsigned 32-bit integers are used because bit shifting is undefined on signed
+ * types.
+ *
+ * An arithmetic shift of `- std::numeric_limits<int64_t>::min()` is done to
+ * remap the `int64_t` value into `uint64_t` space, while maintaining order.
+ * This relies on unsigned arithmetic overflow behavior, which is well-defined.
+ *
+ * Taken from vctrs:
+ * https://github.com/r-lib/vctrs/blob/c27b6988bd2f02aa970b6d14a640eccb299e03bb/src/type-integer64.c#L117-L156
+ */
+
+static
+inline
+std::pair<double, double>
+int64_unpack(int64_t x)
+{
+  const uint64_t x_u64 = static_cast<uint64_t>(x) - std::numeric_limits<int64_t>::min();
+
+  const uint32_t left_u32 = static_cast<uint32_t>(x_u64 >> 32);
+  const uint32_t right_u32 = static_cast<uint32_t>(x_u64);
+
+  const double left_out = static_cast<double>(left_u32);
+  const double right_out = static_cast<double>(right_u32);
+
+  return std::make_pair(left_out, right_out);
+}
+
+static
+inline
+int64_t int64_pack(double left, double right)
+{
+  const uint32_t left_u32 = static_cast<uint32_t>(left);
+  const uint32_t right_u32 = static_cast<uint32_t>(right);
+
+  const uint64_t out_u64 = static_cast<uint64_t>(left_u32) << 32 | right_u32;
+
+  const int64_t out = static_cast<int64_t>(out_u64 + std::numeric_limits<int64_t>::min());
+
+  return out;
+}
+
+} // namespace details
+
+template <typename Duration>
+inline
+void
+duration<Duration>::assign(const Duration& x, r_ssize i)
+{
+  const int64_t elt = static_cast<int64_t>(x.count());
+  std::pair<double, double> unpacked = detail::int64_unpack(elt);
+  lower_.assign(unpacked.first, i);
+  upper_.assign(unpacked.second, i);
+}
+
+template <typename Duration>
+CONSTCD11
+inline
+Duration
+duration<Duration>::operator[](r_ssize i) const NOEXCEPT
+{
+  using rep = typename Duration::rep;
+  const int64_t packed = detail::int64_pack(lower_[i], upper_[i]);
+  const rep elt = static_cast<rep>(packed);
+  return Duration{elt};
+}
+
+template <typename Duration>
+inline
+cpp11::writable::list
+duration<Duration>::to_list() const
+{
+  cpp11::writable::list out({lower_.sexp(), upper_.sexp()});
+  out.names() = {"lower", "upper"};
+  return out;
+}
 
 namespace detail {
 
@@ -22,21 +228,24 @@ info_unique(const date::local_info& info, const date::local_time<Duration>& lt)
 template <typename Duration>
 inline
 date::sys_time<Duration>
-info_nonexistent_roll_forward(const date::local_info& info) {
+info_nonexistent_roll_forward(const date::local_info& info)
+{
   return info.second.begin;
 }
 
 template <typename Duration>
 inline
 date::sys_time<Duration>
-info_nonexistent_roll_backward(const date::local_info& info) {
+info_nonexistent_roll_backward(const date::local_info& info)
+{
   return info_nonexistent_roll_forward<Duration>(info) - Duration{1};
 }
 
 template <typename Duration>
 inline
 date::sys_time<Duration>
-info_nonexistent_shift_forward(const date::local_info& info, const date::local_time<Duration>& lt) {
+info_nonexistent_shift_forward(const date::local_info& info, const date::local_time<Duration>& lt)
+{
   std::chrono::seconds offset = info.second.offset;
   std::chrono::seconds gap = info.second.offset - info.first.offset;
   date::local_time<Duration> lt_shift = lt + gap;
@@ -46,7 +255,8 @@ info_nonexistent_shift_forward(const date::local_info& info, const date::local_t
 template <typename Duration>
 inline
 date::sys_time<Duration>
-info_nonexistent_shift_backward(const date::local_info& info, const date::local_time<Duration>& lt) {
+info_nonexistent_shift_backward(const date::local_info& info, const date::local_time<Duration>& lt)
+{
   std::chrono::seconds offset = info.first.offset;
   std::chrono::seconds gap = info.second.offset - info.first.offset;
   date::local_time<Duration> lt_shift = lt - gap;
@@ -55,7 +265,8 @@ info_nonexistent_shift_backward(const date::local_info& info, const date::local_
 
 inline
 void
-info_nonexistent_error(const r_ssize& i) {
+info_nonexistent_error(const r_ssize& i)
+{
   cpp11::writable::integers arg(1);
   arg[0] = (int) i + 1;
   auto stop = cpp11::package("clock")["stop_clock_nonexistent_time"];
@@ -65,7 +276,8 @@ info_nonexistent_error(const r_ssize& i) {
 template <typename Duration>
 inline
 date::sys_time<Duration>
-info_ambiguous_earliest(const date::local_info& info, const date::local_time<Duration>& lt) {
+info_ambiguous_earliest(const date::local_info& info, const date::local_time<Duration>& lt)
+{
   std::chrono::seconds offset = info.first.offset;
   return date::sys_time<Duration>{lt.time_since_epoch()} - offset;
 }
@@ -73,14 +285,16 @@ info_ambiguous_earliest(const date::local_info& info, const date::local_time<Dur
 template <typename Duration>
 inline
 date::sys_time<Duration>
-info_ambiguous_latest(const date::local_info& info, const date::local_time<Duration>& lt) {
+info_ambiguous_latest(const date::local_info& info, const date::local_time<Duration>& lt)
+{
   std::chrono::seconds offset = info.second.offset;
   return date::sys_time<Duration>{lt.time_since_epoch()} - offset;
 }
 
 inline
 void
-info_ambiguous_error(const r_ssize& i) {
+info_ambiguous_error(const r_ssize& i)
+{
   cpp11::writable::integers arg(1);
   arg[0] = (int) i + 1;
   auto stop = cpp11::package("clock")["stop_clock_ambiguous_time"];
@@ -89,416 +303,18 @@ info_ambiguous_error(const r_ssize& i) {
 
 } // namespace detail
 
-namespace duration {
-
-template <typename Duration>
-class duration1
-{
-protected:
-  rclock::integers ticks_;
-
-public:
-  CONSTCD11 duration1(const cpp11::integers& ticks) NOEXCEPT;
-  duration1(r_ssize size);
-
-  CONSTCD11 bool is_na(r_ssize i) const NOEXCEPT;
-  CONSTCD11 r_ssize size() const NOEXCEPT;
-
-  void assign_na(r_ssize i);
-  void assign(const Duration& x, r_ssize i);
-
-  CONSTCD11 Duration operator[](r_ssize i) const NOEXCEPT;
-
-  cpp11::writable::list to_list() const;
-
-  using duration = Duration;
-};
-
-using years = duration1<date::years>;
-using quarters = duration1<quarterly::quarters>;
-using months = duration1<date::months>;
-using weeks = duration1<date::weeks>;
-using days = duration1<date::days>;
-
-template <typename Duration>
-class duration2 : public duration1<date::days>
-{
-protected:
-  rclock::integers ticks_of_day_;
-
-public:
-  CONSTCD11 duration2(const cpp11::integers& ticks,
-                      const cpp11::integers& ticks_of_day) NOEXCEPT;
-  duration2(r_ssize size);
-
-  void assign_na(r_ssize i);
-  void assign(const Duration& x, r_ssize i);
-
-  void convert_local_to_sys_and_assign(const date::local_seconds& x,
-                                       const date::local_info& info,
-                                       const enum nonexistent& nonexistent_val,
-                                       const enum ambiguous& ambiguous_val,
-                                       const r_ssize& i);
-
-  void convert_local_with_reference_to_sys_and_assign(const date::local_seconds& x,
-                                                      const date::local_info& info,
-                                                      const enum nonexistent& nonexistent_val,
-                                                      const enum ambiguous& ambiguous_val,
-                                                      const date::sys_seconds& reference,
-                                                      const date::time_zone* p_time_zone,
-                                                      const r_ssize& i);
-
-  CONSTCD11 Duration operator[](r_ssize i) const NOEXCEPT;
-
-  cpp11::writable::list to_list() const;
-
-  using duration = Duration;
-};
-
-using hours = duration2<std::chrono::hours>;
-using minutes = duration2<std::chrono::minutes>;
-using seconds = duration2<std::chrono::seconds>;
-
-template <typename Duration>
-class duration3 : public duration2<std::chrono::seconds>
-{
-protected:
-  rclock::integers ticks_of_second_;
-
-public:
-  CONSTCD11 duration3(const cpp11::integers& ticks,
-                      const cpp11::integers& ticks_of_day,
-                      const cpp11::integers& ticks_of_second) NOEXCEPT;
-  duration3(r_ssize size);
-
-  void assign_na(r_ssize i);
-  void assign(const Duration& x, r_ssize i);
-
-  void convert_local_to_sys_and_assign(const date::local_time<Duration>& x,
-                                       const date::local_info& info,
-                                       const enum nonexistent& nonexistent_val,
-                                       const enum ambiguous& ambiguous_val,
-                                       const r_ssize& i);
-
-  void convert_local_with_reference_to_sys_and_assign(const date::local_time<Duration>& x,
-                                                      const date::local_info& info,
-                                                      const enum nonexistent& nonexistent_val,
-                                                      const enum ambiguous& ambiguous_val,
-                                                      const date::sys_seconds& reference,
-                                                      const date::time_zone* p_time_zone,
-                                                      const r_ssize& i);
-
-  CONSTCD11 Duration operator[](r_ssize i) const NOEXCEPT;
-
-  cpp11::writable::list to_list() const;
-
-  using duration = Duration;
-};
-
-using milliseconds = duration3<std::chrono::milliseconds>;
-using microseconds = duration3<std::chrono::microseconds>;
-using nanoseconds = duration3<std::chrono::nanoseconds>;
-
-// Implementation
-
-// duration1
-
-template <typename Duration>
-CONSTCD11
-inline
-duration1<Duration>::duration1(const cpp11::integers& ticks) NOEXCEPT
-  : ticks_(ticks)
-  {}
-
-template <typename Duration>
-inline
-duration1<Duration>::duration1(r_ssize size)
-  : ticks_(size)
-  {}
-
-template <typename Duration>
-CONSTCD11
-inline
-bool
-duration1<Duration>::is_na(r_ssize i) const NOEXCEPT
-{
-  return ticks_[i] == r_int_na;
-}
-
-template <typename Duration>
-CONSTCD11
-inline
-r_ssize
-duration1<Duration>::size() const NOEXCEPT
-{
-  return ticks_.size();
-}
-
-template <typename Duration>
-inline
-void
-duration1<Duration>::assign_na(r_ssize i)
-{
-  ticks_.assign_na(i);
-}
-
-template <typename Duration>
-inline
-void
-duration1<Duration>::assign(const Duration& x, r_ssize i)
-{
-  ticks_.assign(x.count(), i);
-}
-
-template <typename Duration>
-CONSTCD11
-inline
-Duration
-duration1<Duration>::operator[](r_ssize i) const NOEXCEPT
-{
-  return Duration{ticks_[i]};
-}
-
-template <typename Duration>
-inline
-cpp11::writable::list
-duration1<Duration>::to_list() const
-{
-  cpp11::writable::list out({ticks_.sexp()});
-  out.names() = {"ticks"};
-  return out;
-}
-
-// duration2
-
-template <typename Duration>
-CONSTCD11
-inline
-duration2<Duration>::duration2(const cpp11::integers& ticks,
-                               const cpp11::integers& ticks_of_day) NOEXCEPT
-  : duration1(ticks),
-    ticks_of_day_(ticks_of_day)
-  {}
-
-template <typename Duration>
-inline
-duration2<Duration>::duration2(r_ssize size)
-  : duration1(size),
-    ticks_of_day_(size)
-  {}
-
-template <typename Duration>
-inline
-void
-duration2<Duration>::assign_na(r_ssize i)
-{
-  duration1::assign_na(i);
-  ticks_of_day_.assign_na(i);
-}
-
-template <typename Duration>
-inline
-void
-duration2<Duration>::assign(const Duration& x, r_ssize i)
-{
-  const date::days tick = date::floor<date::days>(x);
-  ticks_.assign(tick.count(), i);
-  ticks_of_day_.assign((x - tick).count(), i);
-}
-
 /*
- * Zoned times have at least seconds precision, so the only specialization
- * required for duration2 is for seconds.
+ * Zoned times have at least seconds precision, so we expect that every
+ * instantiation of this will have a `Duration` of at least second precision
  */
-template <>
-inline
-void
-duration2<std::chrono::seconds>::convert_local_to_sys_and_assign(const date::local_seconds& x,
-                                                                 const date::local_info& info,
-                                                                 const enum nonexistent& nonexistent_val,
-                                                                 const enum ambiguous& ambiguous_val,
-                                                                 const r_ssize& i)
-{
-  switch (info.result) {
-  case date::local_info::unique: {
-    date::sys_time<std::chrono::seconds> st = detail::info_unique(info, x);
-    assign(st.time_since_epoch(), i);
-    break;
-  }
-  case date::local_info::nonexistent: {
-    switch (nonexistent_val) {
-    case nonexistent::roll_forward: {
-      date::sys_time<std::chrono::seconds> st = detail::info_nonexistent_roll_forward<std::chrono::seconds>(info);
-      assign(st.time_since_epoch(), i);
-      break;
-    }
-    case nonexistent::roll_backward: {
-      date::sys_time<std::chrono::seconds> st = detail::info_nonexistent_roll_backward<std::chrono::seconds>(info);
-      assign(st.time_since_epoch(), i);
-      break;
-    }
-    case nonexistent::shift_forward: {
-      date::sys_time<std::chrono::seconds> st = detail::info_nonexistent_shift_forward(info, x);
-      assign(st.time_since_epoch(), i);
-      break;
-    }
-    case nonexistent::shift_backward: {
-      date::sys_time<std::chrono::seconds> st = detail::info_nonexistent_shift_backward(info, x);
-      assign(st.time_since_epoch(), i);
-      break;
-    }
-    case nonexistent::na: {
-      assign_na(i);
-      break;
-    }
-    case nonexistent::error: {
-      detail::info_nonexistent_error(i);
-    }
-    }
-    break;
-  }
-  case date::local_info::ambiguous: {
-    switch (ambiguous_val) {
-    case ambiguous::earliest: {
-      date::sys_time<std::chrono::seconds> st = detail::info_ambiguous_earliest(info, x);
-      assign(st.time_since_epoch(), i);
-      break;
-    }
-    case ambiguous::latest: {
-      date::sys_time<std::chrono::seconds> st = detail::info_ambiguous_latest(info, x);
-      assign(st.time_since_epoch(), i);
-      break;
-    }
-    case ambiguous::na: {
-      assign_na(i);
-      break;
-    }
-    case ambiguous::error: {
-      detail::info_ambiguous_error(i);
-    }
-    }
-    break;
-  }
-  }
-}
-
-/*
- * Zoned times have at least seconds precision, so the only specialization
- * required for duration2 is for seconds.
- */
-template <>
-inline
-void
-duration2<std::chrono::seconds>::convert_local_with_reference_to_sys_and_assign(const date::local_seconds& x,
-                                                                                const date::local_info& info,
-                                                                                const enum nonexistent& nonexistent_val,
-                                                                                const enum ambiguous& ambiguous_val,
-                                                                                const date::sys_seconds& reference,
-                                                                                const date::time_zone* p_time_zone,
-                                                                                const r_ssize& i)
-{
-  if (info.result == date::local_info::unique ||
-      info.result == date::local_info::nonexistent) {
-    // For `unique` and `nonexistent`, nothing changes
-    convert_local_to_sys_and_assign(x, info, nonexistent_val, ambiguous_val, i);
-    return;
-  }
-
-  const date::local_seconds ref_lt = rclock::get_local_time(reference, p_time_zone);
-  const date::local_info ref_info = rclock::get_info(ref_lt, p_time_zone);
-
-  if (ref_info.result != date::local_info::ambiguous) {
-    // If reference time is not ambiguous, we can't get any offset information
-    // from it so fallback to using `ambiguous_val`
-    convert_local_to_sys_and_assign(x, info, nonexistent_val, ambiguous_val, i);
-    return;
-  }
-  if (ref_info.first.end != info.first.end) {
-    // If reference time is ambiguous, but the transitions don't match,
-    // we again can't get offset information from it
-    convert_local_to_sys_and_assign(x, info, nonexistent_val, ambiguous_val, i);
-    return;
-  }
-
-  const std::chrono::seconds offset =
-    reference < ref_info.first.end ?
-    ref_info.first.offset :
-    ref_info.second.offset;
-
-  const date::sys_seconds st = date::sys_seconds{x.time_since_epoch()} - offset;
-
-  assign(st.time_since_epoch(), i);
-}
-
-template <typename Duration>
-CONSTCD11
-inline
-Duration
-duration2<Duration>::operator[](r_ssize i) const NOEXCEPT
-{
-  return duration1::operator[](i) + Duration{ticks_of_day_[i]};
-}
-
-template <typename Duration>
-inline
-cpp11::writable::list
-duration2<Duration>::to_list() const
-{
-  cpp11::writable::list out({ticks_.sexp(), ticks_of_day_.sexp()});
-  out.names() = {"ticks", "ticks_of_day"};
-  return out;
-}
-
-// duration3
-
-template <typename Duration>
-CONSTCD11
-inline
-duration3<Duration>::duration3(const cpp11::integers& ticks,
-                               const cpp11::integers& ticks_of_day,
-                               const cpp11::integers& ticks_of_second) NOEXCEPT
-  : duration2(ticks, ticks_of_day),
-    ticks_of_second_(ticks_of_second)
-  {}
-
-template <typename Duration>
-inline
-duration3<Duration>::duration3(r_ssize size)
-  : duration2(size),
-    ticks_of_second_(size)
-  {}
-
 template <typename Duration>
 inline
 void
-duration3<Duration>::assign_na(r_ssize i)
-{
-  duration2::assign_na(i);
-  ticks_of_second_.assign_na(i);
-}
-
-template <typename Duration>
-inline
-void
-duration3<Duration>::assign(const Duration& x, r_ssize i)
-{
-  const date::days tick = date::floor<date::days>(x);
-  const Duration x_of_day = x - tick;
-  const std::chrono::seconds tick_of_day = date::floor<std::chrono::seconds>(x_of_day);
-  const Duration tick_of_second = x_of_day - tick_of_day;
-  ticks_.assign(tick.count(), i);
-  ticks_of_day_.assign(tick_of_day.count(), i);
-  ticks_of_second_.assign(tick_of_second.count(), i);
-}
-
-template <typename Duration>
-inline
-void
-duration3<Duration>::convert_local_to_sys_and_assign(const date::local_time<Duration>& x,
-                                                     const date::local_info& info,
-                                                     const enum nonexistent& nonexistent_val,
-                                                     const enum ambiguous& ambiguous_val,
-                                                     const r_ssize& i)
+duration<Duration>::convert_local_to_sys_and_assign(const date::local_time<Duration>& x,
+                                                    const date::local_info& info,
+                                                    const enum nonexistent& nonexistent_val,
+                                                    const enum ambiguous& ambiguous_val,
+                                                    const r_ssize& i)
 {
   switch (info.result) {
   case date::local_info::unique: {
@@ -566,13 +382,13 @@ duration3<Duration>::convert_local_to_sys_and_assign(const date::local_time<Dura
 template <typename Duration>
 inline
 void
-duration3<Duration>::convert_local_with_reference_to_sys_and_assign(const date::local_time<Duration>& x,
-                                                                    const date::local_info& info,
-                                                                    const enum nonexistent& nonexistent_val,
-                                                                    const enum ambiguous& ambiguous_val,
-                                                                    const date::sys_seconds& reference,
-                                                                    const date::time_zone* p_time_zone,
-                                                                    const r_ssize& i)
+duration<Duration>::convert_local_with_reference_to_sys_and_assign(const date::local_time<Duration>& x,
+                                                                   const date::local_info& info,
+                                                                   const enum nonexistent& nonexistent_val,
+                                                                   const enum ambiguous& ambiguous_val,
+                                                                   const date::sys_seconds& reference,
+                                                                   const date::time_zone* p_time_zone,
+                                                                   const r_ssize& i)
 {
   if (info.result == date::local_info::unique ||
       info.result == date::local_info::nonexistent) {
@@ -607,70 +423,15 @@ duration3<Duration>::convert_local_with_reference_to_sys_and_assign(const date::
   assign(st.time_since_epoch(), i);
 }
 
-template <typename Duration>
-CONSTCD11
-inline
-Duration
-duration3<Duration>::operator[](r_ssize i) const NOEXCEPT
-{
-  return duration2::operator[](i) + Duration{ticks_of_second_[i]};
-}
-
-template <typename Duration>
-inline
-cpp11::writable::list
-duration3<Duration>::to_list() const
-{
-  cpp11::writable::list out({ticks_.sexp(), ticks_of_day_.sexp(), ticks_of_second_.sexp()});
-  out.names() = {"ticks", "ticks_of_day", "ticks_of_second"};
-  return out;
-}
-
 } // namespace duration
 
 } // namespace rclock
 
-/*
- * `std::common_type()` specializations for `rclock::duration` types.
- */
+// `std::common_type()` specialization for `rclock::duration` types
 namespace std {
   template<class Duration1, class Duration2>
-  struct common_type<rclock::duration::duration1<Duration1>, rclock::duration::duration1<Duration2>> {
-    using type = rclock::duration::duration1<typename std::common_type<Duration1, Duration2>::type>;
-  };
-  template<class Duration1, class Duration2>
-  struct common_type<rclock::duration::duration1<Duration1>, rclock::duration::duration2<Duration2>> {
-    using type = rclock::duration::duration2<typename std::common_type<Duration1, Duration2>::type>;
-  };
-  template<class Duration1, class Duration2>
-  struct common_type<rclock::duration::duration1<Duration1>, rclock::duration::duration3<Duration2>> {
-    using type = rclock::duration::duration3<typename std::common_type<Duration1, Duration2>::type>;
-  };
-
-  template<class Duration1, class Duration2>
-  struct common_type<rclock::duration::duration2<Duration1>, rclock::duration::duration1<Duration2>> {
-    using type = rclock::duration::duration2<typename std::common_type<Duration1, Duration2>::type>;
-  };
-  template<class Duration1, class Duration2>
-  struct common_type<rclock::duration::duration2<Duration1>, rclock::duration::duration2<Duration2>> {
-    using type = rclock::duration::duration2<typename std::common_type<Duration1, Duration2>::type>;
-  };
-  template<class Duration1, class Duration2>
-  struct common_type<rclock::duration::duration2<Duration1>, rclock::duration::duration3<Duration2>> {
-    using type = rclock::duration::duration3<typename std::common_type<Duration1, Duration2>::type>;
-  };
-
-  template<class Duration1, class Duration2>
-  struct common_type<rclock::duration::duration3<Duration1>, rclock::duration::duration1<Duration2>> {
-    using type = rclock::duration::duration3<typename std::common_type<Duration1, Duration2>::type>;
-  };
-  template<class Duration1, class Duration2>
-  struct common_type<rclock::duration::duration3<Duration1>, rclock::duration::duration2<Duration2>> {
-    using type = rclock::duration::duration3<typename std::common_type<Duration1, Duration2>::type>;
-  };
-  template<class Duration1, class Duration2>
-  struct common_type<rclock::duration::duration3<Duration1>, rclock::duration::duration3<Duration2>> {
-    using type = rclock::duration::duration3<typename std::common_type<Duration1, Duration2>::type>;
+  struct common_type<rclock::duration::duration<Duration1>, rclock::duration::duration<Duration2>> {
+    using type = rclock::duration::duration<typename std::common_type<Duration1, Duration2>::type>;
   };
 }
 

--- a/src/get.h
+++ b/src/get.h
@@ -296,35 +296,4 @@ get_subsecond(cpp11::list_of<cpp11::integers>& fields) {
 
 } // namespace rclock
 
-// -----------------------------------------------------------------------------
-
-namespace rclock {
-
-namespace duration {
-
-static
-inline
-cpp11::integers
-get_ticks(cpp11::list_of<cpp11::integers>& fields) {
-  return fields.size() >= 1 ? fields[0] : cpp11::integers{};
-}
-
-static
-inline
-cpp11::integers
-get_ticks_of_day(cpp11::list_of<cpp11::integers>& fields) {
-  return fields.size() >= 2 ? fields[1] : cpp11::integers{};
-}
-
-static
-inline
-cpp11::integers
-get_ticks_of_second(cpp11::list_of<cpp11::integers>& fields) {
-  return fields.size() >= 3 ? fields[2] : cpp11::integers{};
-}
-
-} // namespace duration
-
-} // namespace rclock
-
 #endif

--- a/src/gregorian-year-day.cpp
+++ b/src/gregorian-year-day.cpp
@@ -219,7 +219,7 @@ get_year_day_last_cpp(const cpp11::integers& year) {
 [[cpp11::register]]
 cpp11::writable::list
 year_day_plus_duration_cpp(cpp11::list_of<cpp11::integers> fields,
-                           cpp11::list_of<cpp11::integers> fields_n,
+                           cpp11::list_of<cpp11::doubles> fields_n,
                            const cpp11::integers& precision_fields,
                            const cpp11::integers& precision_n) {
   using namespace rclock;
@@ -243,9 +243,7 @@ year_day_plus_duration_cpp(cpp11::list_of<cpp11::integers> fields,
   yearday::yydhmss<std::chrono::microseconds> yydhmss2{year, day, hour, minute, second, subsecond};
   yearday::yydhmss<std::chrono::nanoseconds> yydhmss3{year, day, hour, minute, second, subsecond};
 
-  cpp11::integers ticks = duration::get_ticks(fields_n);
-
-  duration::years dy{ticks};
+  duration::years dy{fields_n};
 
   switch (precision_fields_val) {
   case precision::year:
@@ -344,30 +342,18 @@ as_sys_time_year_day_cpp(cpp11::list_of<cpp11::integers> fields,
 
 [[cpp11::register]]
 cpp11::writable::list
-as_year_day_from_sys_time_cpp(cpp11::list_of<cpp11::integers> fields,
+as_year_day_from_sys_time_cpp(cpp11::list_of<cpp11::doubles> fields,
                               const cpp11::integers& precision_int) {
   using namespace rclock;
 
-  cpp11::integers ticks = duration::get_ticks(fields);
-  cpp11::integers ticks_of_day = duration::get_ticks_of_day(fields);
-  cpp11::integers ticks_of_second = duration::get_ticks_of_second(fields);
-
-  duration::days dd{ticks};
-  duration::hours dh{ticks, ticks_of_day};
-  duration::minutes dmin{ticks, ticks_of_day};
-  duration::seconds ds{ticks, ticks_of_day};
-  duration::milliseconds dmilli{ticks, ticks_of_day, ticks_of_second};
-  duration::microseconds dmicro{ticks, ticks_of_day, ticks_of_second};
-  duration::nanoseconds dnano{ticks, ticks_of_day, ticks_of_second};
-
   switch (parse_precision(precision_int)) {
-  case precision::day: return as_calendar_from_sys_time_impl<yearday::yyd>(dd);
-  case precision::hour: return as_calendar_from_sys_time_impl<yearday::yydh>(dh);
-  case precision::minute: return as_calendar_from_sys_time_impl<yearday::yydhm>(dmin);
-  case precision::second: return as_calendar_from_sys_time_impl<yearday::yydhms>(ds);
-  case precision::millisecond: return as_calendar_from_sys_time_impl<yearday::yydhmss<std::chrono::milliseconds>>(dmilli);
-  case precision::microsecond: return as_calendar_from_sys_time_impl<yearday::yydhmss<std::chrono::microseconds>>(dmicro);
-  case precision::nanosecond: return as_calendar_from_sys_time_impl<yearday::yydhmss<std::chrono::nanoseconds>>(dnano);
+  case precision::day: return as_calendar_from_sys_time_impl<duration::days, yearday::yyd>(fields);
+  case precision::hour: return as_calendar_from_sys_time_impl<duration::hours, yearday::yydh>(fields);
+  case precision::minute: return as_calendar_from_sys_time_impl<duration::minutes, yearday::yydhm>(fields);
+  case precision::second: return as_calendar_from_sys_time_impl<duration::seconds, yearday::yydhms>(fields);
+  case precision::millisecond: return as_calendar_from_sys_time_impl<duration::milliseconds, yearday::yydhmss<std::chrono::milliseconds>>(fields);
+  case precision::microsecond: return as_calendar_from_sys_time_impl<duration::microseconds, yearday::yydhmss<std::chrono::microseconds>>(fields);
+  case precision::nanosecond: return as_calendar_from_sys_time_impl<duration::nanoseconds, yearday::yydhmss<std::chrono::nanoseconds>>(fields);
   default: clock_abort("Internal error: Invalid precision.");
   }
 

--- a/src/gregorian-year-month-day.cpp
+++ b/src/gregorian-year-month-day.cpp
@@ -231,7 +231,7 @@ get_year_month_day_last_cpp(const cpp11::integers& year,
 [[cpp11::register]]
 cpp11::writable::list
 year_month_day_plus_duration_cpp(cpp11::list_of<cpp11::integers> fields,
-                                 cpp11::list_of<cpp11::integers> fields_n,
+                                 cpp11::list_of<cpp11::doubles> fields_n,
                                  const cpp11::integers& precision_fields,
                                  const cpp11::integers& precision_n) {
   using namespace rclock;
@@ -257,11 +257,9 @@ year_month_day_plus_duration_cpp(cpp11::list_of<cpp11::integers> fields,
   gregorian::ymdhmss<std::chrono::microseconds> ymdhmss2{year, month, day, hour, minute, second, subsecond};
   gregorian::ymdhmss<std::chrono::nanoseconds> ymdhmss3{year, month, day, hour, minute, second, subsecond};
 
-  cpp11::integers ticks = duration::get_ticks(fields_n);
-
-  duration::years dy{ticks};
-  duration::quarters dq{ticks};
-  duration::months dm{ticks};
+  duration::years dy{fields_n};
+  duration::quarters dq{fields_n};
+  duration::months dm{fields_n};
 
   switch (precision_fields_val) {
   case precision::year:
@@ -382,30 +380,18 @@ as_sys_time_year_month_day_cpp(cpp11::list_of<cpp11::integers> fields,
 
 [[cpp11::register]]
 cpp11::writable::list
-as_year_month_day_from_sys_time_cpp(cpp11::list_of<cpp11::integers> fields,
+as_year_month_day_from_sys_time_cpp(cpp11::list_of<cpp11::doubles> fields,
                                     const cpp11::integers& precision_int) {
   using namespace rclock;
 
-  cpp11::integers ticks = duration::get_ticks(fields);
-  cpp11::integers ticks_of_day = duration::get_ticks_of_day(fields);
-  cpp11::integers ticks_of_second = duration::get_ticks_of_second(fields);
-
-  duration::days dd{ticks};
-  duration::hours dh{ticks, ticks_of_day};
-  duration::minutes dmin{ticks, ticks_of_day};
-  duration::seconds ds{ticks, ticks_of_day};
-  duration::milliseconds dmilli{ticks, ticks_of_day, ticks_of_second};
-  duration::microseconds dmicro{ticks, ticks_of_day, ticks_of_second};
-  duration::nanoseconds dnano{ticks, ticks_of_day, ticks_of_second};
-
   switch (parse_precision(precision_int)) {
-  case precision::day: return as_calendar_from_sys_time_impl<gregorian::ymd>(dd);
-  case precision::hour: return as_calendar_from_sys_time_impl<gregorian::ymdh>(dh);
-  case precision::minute: return as_calendar_from_sys_time_impl<gregorian::ymdhm>(dmin);
-  case precision::second: return as_calendar_from_sys_time_impl<gregorian::ymdhms>(ds);
-  case precision::millisecond: return as_calendar_from_sys_time_impl<gregorian::ymdhmss<std::chrono::milliseconds>>(dmilli);
-  case precision::microsecond: return as_calendar_from_sys_time_impl<gregorian::ymdhmss<std::chrono::microseconds>>(dmicro);
-  case precision::nanosecond: return as_calendar_from_sys_time_impl<gregorian::ymdhmss<std::chrono::nanoseconds>>(dnano);
+  case precision::day: return as_calendar_from_sys_time_impl<duration::days, gregorian::ymd>(fields);
+  case precision::hour: return as_calendar_from_sys_time_impl<duration::hours, gregorian::ymdh>(fields);
+  case precision::minute: return as_calendar_from_sys_time_impl<duration::minutes, gregorian::ymdhm>(fields);
+  case precision::second: return as_calendar_from_sys_time_impl<duration::seconds, gregorian::ymdhms>(fields);
+  case precision::millisecond: return as_calendar_from_sys_time_impl<duration::milliseconds, gregorian::ymdhmss<std::chrono::milliseconds>>(fields);
+  case precision::microsecond: return as_calendar_from_sys_time_impl<duration::microseconds, gregorian::ymdhmss<std::chrono::microseconds>>(fields);
+  case precision::nanosecond: return as_calendar_from_sys_time_impl<duration::nanoseconds, gregorian::ymdhmss<std::chrono::nanoseconds>>(fields);
   default: clock_abort("Internal error: Invalid precision.");
   }
 

--- a/src/gregorian-year-month-weekday.cpp
+++ b/src/gregorian-year-month-weekday.cpp
@@ -237,7 +237,7 @@ get_year_month_weekday_last_cpp(const cpp11::integers& year,
 [[cpp11::register]]
 cpp11::writable::list
 year_month_weekday_plus_duration_cpp(cpp11::list_of<cpp11::integers> fields,
-                                     cpp11::list_of<cpp11::integers> fields_n,
+                                     cpp11::list_of<cpp11::doubles> fields_n,
                                      const cpp11::integers& precision_fields,
                                      const cpp11::integers& precision_n) {
   using namespace rclock;
@@ -264,11 +264,9 @@ year_month_weekday_plus_duration_cpp(cpp11::list_of<cpp11::integers> fields,
   weekday::ymwdhmss<std::chrono::microseconds> ymwdhmss2{year, month, day, index, hour, minute, second, subsecond};
   weekday::ymwdhmss<std::chrono::nanoseconds> ymwdhmss3{year, month, day, index, hour, minute, second, subsecond};
 
-  cpp11::integers ticks = duration::get_ticks(fields_n);
-
-  duration::years dy{ticks};
-  duration::quarters dq{ticks};
-  duration::months dm{ticks};
+  duration::years dy{fields_n};
+  duration::quarters dq{fields_n};
+  duration::months dm{fields_n};
 
   switch (precision_fields_val) {
   case precision::year:
@@ -390,30 +388,18 @@ as_sys_time_year_month_weekday_cpp(cpp11::list_of<cpp11::integers> fields,
 
 [[cpp11::register]]
 cpp11::writable::list
-as_year_month_weekday_from_sys_time_cpp(cpp11::list_of<cpp11::integers> fields,
+as_year_month_weekday_from_sys_time_cpp(cpp11::list_of<cpp11::doubles> fields,
                                         const cpp11::integers& precision_int) {
   using namespace rclock;
 
-  cpp11::integers ticks = duration::get_ticks(fields);
-  cpp11::integers ticks_of_day = duration::get_ticks_of_day(fields);
-  cpp11::integers ticks_of_second = duration::get_ticks_of_second(fields);
-
-  duration::days dd{ticks};
-  duration::hours dh{ticks, ticks_of_day};
-  duration::minutes dmin{ticks, ticks_of_day};
-  duration::seconds ds{ticks, ticks_of_day};
-  duration::milliseconds dmilli{ticks, ticks_of_day, ticks_of_second};
-  duration::microseconds dmicro{ticks, ticks_of_day, ticks_of_second};
-  duration::nanoseconds dnano{ticks, ticks_of_day, ticks_of_second};
-
   switch (parse_precision(precision_int)) {
-  case precision::day: return as_calendar_from_sys_time_impl<weekday::ymwd>(dd);
-  case precision::hour: return as_calendar_from_sys_time_impl<weekday::ymwdh>(dh);
-  case precision::minute: return as_calendar_from_sys_time_impl<weekday::ymwdhm>(dmin);
-  case precision::second: return as_calendar_from_sys_time_impl<weekday::ymwdhms>(ds);
-  case precision::millisecond: return as_calendar_from_sys_time_impl<weekday::ymwdhmss<std::chrono::milliseconds>>(dmilli);
-  case precision::microsecond: return as_calendar_from_sys_time_impl<weekday::ymwdhmss<std::chrono::microseconds>>(dmicro);
-  case precision::nanosecond: return as_calendar_from_sys_time_impl<weekday::ymwdhmss<std::chrono::nanoseconds>>(dnano);
+  case precision::day: return as_calendar_from_sys_time_impl<duration::days, weekday::ymwd>(fields);
+  case precision::hour: return as_calendar_from_sys_time_impl<duration::hours, weekday::ymwdh>(fields);
+  case precision::minute: return as_calendar_from_sys_time_impl<duration::minutes, weekday::ymwdhm>(fields);
+  case precision::second: return as_calendar_from_sys_time_impl<duration::seconds, weekday::ymwdhms>(fields);
+  case precision::millisecond: return as_calendar_from_sys_time_impl<duration::milliseconds, weekday::ymwdhmss<std::chrono::milliseconds>>(fields);
+  case precision::microsecond: return as_calendar_from_sys_time_impl<duration::microseconds, weekday::ymwdhmss<std::chrono::microseconds>>(fields);
+  case precision::nanosecond: return as_calendar_from_sys_time_impl<duration::nanoseconds, weekday::ymwdhmss<std::chrono::nanoseconds>>(fields);
   default: clock_abort("Internal error: Invalid precision.");
   }
 

--- a/src/iso-year-week-day.cpp
+++ b/src/iso-year-week-day.cpp
@@ -226,7 +226,7 @@ get_iso_year_week_day_last_cpp(const cpp11::integers& year) {
 [[cpp11::register]]
 cpp11::writable::list
 iso_year_week_day_plus_duration_cpp(cpp11::list_of<cpp11::integers> fields,
-                                    cpp11::list_of<cpp11::integers> fields_n,
+                                    cpp11::list_of<cpp11::doubles> fields_n,
                                     const cpp11::integers& precision_fields,
                                     const cpp11::integers& precision_n) {
   using namespace rclock;
@@ -252,9 +252,7 @@ iso_year_week_day_plus_duration_cpp(cpp11::list_of<cpp11::integers> fields,
   iso::ywnwdhmss<std::chrono::microseconds> ywnwdhmss2{year, week, day, hour, minute, second, subsecond};
   iso::ywnwdhmss<std::chrono::nanoseconds> ywnwdhmss3{year, week, day, hour, minute, second, subsecond};
 
-  cpp11::integers ticks = duration::get_ticks(fields_n);
-
-  duration::years dy{ticks};
+  duration::years dy{fields_n};
 
   switch (precision_fields_val) {
   case precision::year:
@@ -359,30 +357,18 @@ as_sys_time_iso_year_week_day_cpp(cpp11::list_of<cpp11::integers> fields,
 
 [[cpp11::register]]
 cpp11::writable::list
-as_iso_year_week_day_from_sys_time_cpp(cpp11::list_of<cpp11::integers> fields,
+as_iso_year_week_day_from_sys_time_cpp(cpp11::list_of<cpp11::doubles> fields,
                                        const cpp11::integers& precision_int) {
   using namespace rclock;
 
-  cpp11::integers ticks = duration::get_ticks(fields);
-  cpp11::integers ticks_of_day = duration::get_ticks_of_day(fields);
-  cpp11::integers ticks_of_second = duration::get_ticks_of_second(fields);
-
-  duration::days dd{ticks};
-  duration::hours dh{ticks, ticks_of_day};
-  duration::minutes dmin{ticks, ticks_of_day};
-  duration::seconds ds{ticks, ticks_of_day};
-  duration::milliseconds dmilli{ticks, ticks_of_day, ticks_of_second};
-  duration::microseconds dmicro{ticks, ticks_of_day, ticks_of_second};
-  duration::nanoseconds dnano{ticks, ticks_of_day, ticks_of_second};
-
   switch (parse_precision(precision_int)) {
-  case precision::day: return as_calendar_from_sys_time_impl<iso::ywnwd>(dd);
-  case precision::hour: return as_calendar_from_sys_time_impl<iso::ywnwdh>(dh);
-  case precision::minute: return as_calendar_from_sys_time_impl<iso::ywnwdhm>(dmin);
-  case precision::second: return as_calendar_from_sys_time_impl<iso::ywnwdhms>(ds);
-  case precision::millisecond: return as_calendar_from_sys_time_impl<iso::ywnwdhmss<std::chrono::milliseconds>>(dmilli);
-  case precision::microsecond: return as_calendar_from_sys_time_impl<iso::ywnwdhmss<std::chrono::microseconds>>(dmicro);
-  case precision::nanosecond: return as_calendar_from_sys_time_impl<iso::ywnwdhmss<std::chrono::nanoseconds>>(dnano);
+  case precision::day: return as_calendar_from_sys_time_impl<duration::days, iso::ywnwd>(fields);
+  case precision::hour: return as_calendar_from_sys_time_impl<duration::hours, iso::ywnwdh>(fields);
+  case precision::minute: return as_calendar_from_sys_time_impl<duration::minutes, iso::ywnwdhm>(fields);
+  case precision::second: return as_calendar_from_sys_time_impl<duration::seconds, iso::ywnwdhms>(fields);
+  case precision::millisecond: return as_calendar_from_sys_time_impl<duration::milliseconds, iso::ywnwdhmss<std::chrono::milliseconds>>(fields);
+  case precision::microsecond: return as_calendar_from_sys_time_impl<duration::microseconds, iso::ywnwdhmss<std::chrono::microseconds>>(fields);
+  case precision::nanosecond: return as_calendar_from_sys_time_impl<duration::nanoseconds, iso::ywnwdhmss<std::chrono::nanoseconds>>(fields);
   default: clock_abort("Internal error: Invalid precision.");
   }
 

--- a/src/naive-time.cpp
+++ b/src/naive-time.cpp
@@ -9,9 +9,11 @@ template <class ClockDuration>
 static
 inline
 cpp11::writable::list
-naive_time_info_impl(const ClockDuration& x, const cpp11::strings& zone) {
+naive_time_info_impl(cpp11::list_of<cpp11::doubles>& fields,
+                     const cpp11::strings& zone) {
+  const ClockDuration x{fields};
   const r_ssize size = x.size();
-  using Duration = typename ClockDuration::duration;
+  using Duration = typename ClockDuration::chrono_duration;
 
   cpp11::writable::strings type(size);
 
@@ -140,27 +142,17 @@ naive_time_info_impl(const ClockDuration& x, const cpp11::strings& zone) {
 
 [[cpp11::register]]
 cpp11::writable::list
-naive_time_info_cpp(cpp11::list_of<cpp11::integers> fields,
+naive_time_info_cpp(cpp11::list_of<cpp11::doubles> fields,
                     const cpp11::integers& precision_int,
                     const cpp11::strings& zone) {
   using namespace rclock;
 
-  const cpp11::integers ticks = duration::get_ticks(fields);
-  const cpp11::integers ticks_of_day = duration::get_ticks_of_day(fields);
-  const cpp11::integers ticks_of_second = duration::get_ticks_of_second(fields);
-
-  const duration::days dd{ticks};
-  const duration::seconds ds{ticks, ticks_of_day};
-  const duration::milliseconds dmilli{ticks, ticks_of_day, ticks_of_second};
-  const duration::microseconds dmicro{ticks, ticks_of_day, ticks_of_second};
-  const duration::nanoseconds dnano{ticks, ticks_of_day, ticks_of_second};
-
   switch (parse_precision(precision_int)) {
-  case precision::day: return naive_time_info_impl(dd, zone);
-  case precision::second: return naive_time_info_impl(ds, zone);
-  case precision::millisecond: return naive_time_info_impl(dmilli, zone);
-  case precision::microsecond: return naive_time_info_impl(dmicro, zone);
-  case precision::nanosecond: return naive_time_info_impl(dnano, zone);
+  case precision::day: return naive_time_info_impl<duration::days>(fields, zone);
+  case precision::second: return naive_time_info_impl<duration::seconds>(fields, zone);
+  case precision::millisecond: return naive_time_info_impl<duration::milliseconds>(fields, zone);
+  case precision::microsecond: return naive_time_info_impl<duration::microseconds>(fields, zone);
+  case precision::nanosecond: return naive_time_info_impl<duration::nanoseconds>(fields, zone);
   default: clock_abort("Internal error: Should never be called.");
   }
 }

--- a/src/rcrd.cpp
+++ b/src/rcrd.cpp
@@ -27,15 +27,15 @@ new_clock_rcrd_from_fields(SEXP fields, SEXP names, SEXP classes) {
   const SEXP* p_fields = r_list_deref_const(fields);
 
   SEXP field0 = p_fields[0];
-  if (TYPEOF(field0) != INTSXP) {
-    clock_abort("All clock_rcrd types have integer fields.");
+  if (TYPEOF(field0) != INTSXP && TYPEOF(field0) != REALSXP) {
+    clock_abort("All clock_rcrd types have integer or double fields.");
   }
   const r_ssize size = Rf_xlength(field0);
 
   for (r_ssize i = 1; i < n_fields; ++i) {
     const SEXP field = p_fields[i];
-    if (TYPEOF(field) != INTSXP) {
-      clock_abort("All clock_rcrd types have integer fields.");
+    if (TYPEOF(field) != INTSXP && TYPEOF(field) != REALSXP) {
+      clock_abort("All clock_rcrd types have integer or double fields.");
     }
     if (Rf_xlength(field) != size) {
       clock_abort("All fields must have the same size.");

--- a/src/sys-time.cpp
+++ b/src/sys-time.cpp
@@ -29,9 +29,12 @@ template <class ClockDuration>
 static
 inline
 cpp11::writable::list
-sys_time_info_impl(const ClockDuration& x, const cpp11::strings& zone) {
+sys_time_info_impl(cpp11::list_of<cpp11::doubles>& fields,
+                   const cpp11::strings& zone) {
+  using Duration = typename ClockDuration::chrono_duration;
+
+  const ClockDuration x{fields};
   const r_ssize size = x.size();
-  using Duration = typename ClockDuration::duration;
 
   rclock::duration::seconds begin(size);
   rclock::duration::seconds end(size);
@@ -88,27 +91,17 @@ sys_time_info_impl(const ClockDuration& x, const cpp11::strings& zone) {
 
 [[cpp11::register]]
 cpp11::writable::list
-sys_time_info_cpp(cpp11::list_of<cpp11::integers> fields,
+sys_time_info_cpp(cpp11::list_of<cpp11::doubles> fields,
                   const cpp11::integers& precision_int,
                   const cpp11::strings& zone) {
   using namespace rclock;
 
-  const cpp11::integers ticks = duration::get_ticks(fields);
-  const cpp11::integers ticks_of_day = duration::get_ticks_of_day(fields);
-  const cpp11::integers ticks_of_second = duration::get_ticks_of_second(fields);
-
-  const duration::days dd{ticks};
-  const duration::seconds ds{ticks, ticks_of_day};
-  const duration::milliseconds dmilli{ticks, ticks_of_day, ticks_of_second};
-  const duration::microseconds dmicro{ticks, ticks_of_day, ticks_of_second};
-  const duration::nanoseconds dnano{ticks, ticks_of_day, ticks_of_second};
-
   switch (parse_precision(precision_int)) {
-  case precision::day: return sys_time_info_impl(dd, zone);
-  case precision::second: return sys_time_info_impl(ds, zone);
-  case precision::millisecond: return sys_time_info_impl(dmilli, zone);
-  case precision::microsecond: return sys_time_info_impl(dmicro, zone);
-  case precision::nanosecond: return sys_time_info_impl(dnano, zone);
+  case precision::day: return sys_time_info_impl<duration::days>(fields, zone);
+  case precision::second: return sys_time_info_impl<duration::seconds>(fields, zone);
+  case precision::millisecond: return sys_time_info_impl<duration::milliseconds>(fields, zone);
+  case precision::microsecond: return sys_time_info_impl<duration::microseconds>(fields, zone);
+  case precision::nanosecond: return sys_time_info_impl<duration::nanoseconds>(fields, zone);
   default: clock_abort("Internal error: Should never be called.");
   }
 }

--- a/src/time-point.cpp
+++ b/src/time-point.cpp
@@ -18,6 +18,9 @@ new_time_point_from_fields(SEXP fields,
   const enum clock_name clock_val = parse_clock_name(clock_int);
 
   const r_ssize n_fields = Rf_xlength(fields);
+  if (n_fields != 2) {
+    clock_abort("`fields` must be length 2.");
+  }
 
   switch (precision_val) {
   case precision::year:
@@ -26,26 +29,13 @@ new_time_point_from_fields(SEXP fields,
   case precision::week: {
     clock_abort("`precision` must be at least 'day' precision.");
   }
-  case precision::day: {
-    if (n_fields != 1) {
-      clock_abort("`fields` must have 1 field for day precision.");
-    }
-    break;
-  }
+  case precision::day:
   case precision::hour:
   case precision::minute:
-  case precision::second: {
-    if (n_fields != 2) {
-      clock_abort("`fields` must have 2 fields for [hour, second] precision.");
-    }
-    break;
-  }
+  case precision::second:
   case precision::millisecond:
   case precision::microsecond:
   case precision::nanosecond: {
-    if (n_fields != 3) {
-      clock_abort("`fields` must have 3 fields for [millisecond, nanosecond] precision.");
-    }
     break;
   }
   default: {
@@ -110,7 +100,7 @@ time_point_parse_one(std::istringstream& stream,
                      const r_ssize& i,
                      rclock::failures& fail,
                      ClockDuration& out) {
-  using Duration = typename ClockDuration::duration;
+  using Duration = typename ClockDuration::chrono_duration;
   const r_ssize size = fmts.size();
 
   for (r_ssize j = 0; j < size; ++j) {

--- a/src/weekday.cpp
+++ b/src/weekday.cpp
@@ -18,24 +18,23 @@ reencode_c_to_western(const unsigned& x) {
 [[cpp11::register]]
 cpp11::writable::integers
 weekday_add_days_cpp(const cpp11::integers& x,
-                     cpp11::list_of<cpp11::integers> n) {
+                     cpp11::list_of<cpp11::doubles> n_fields) {
   const r_ssize size = x.size();
 
-  const cpp11::integers ticks = rclock::duration::get_ticks(n);
-  const rclock::duration::days d{ticks};
+  const rclock::duration::days n{n_fields};
 
   cpp11::writable::integers out(size);
 
   for (r_ssize i = 0; i < size; ++i) {
     const int elt = x[i];
 
-    if (elt == r_int_na || d.is_na(i)) {
+    if (elt == r_int_na || n.is_na(i)) {
       out[i] = r_int_na;
       continue;
     }
 
     const unsigned weekday = reencode_western_to_c(static_cast<unsigned>(elt));
-    const date::weekday out_elt = date::weekday{weekday} + d[i];
+    const date::weekday out_elt = date::weekday{weekday} + n[i];
     out[i] = static_cast<int>(reencode_c_to_western(out_elt.c_encoding()));
   }
 
@@ -70,20 +69,19 @@ weekday_minus_weekday_cpp(const cpp11::integers& x, const cpp11::integers& y) {
 
 [[cpp11::register]]
 cpp11::writable::integers
-weekday_from_time_point_cpp(cpp11::list_of<cpp11::integers> x) {
-  const cpp11::integers ticks = rclock::duration::get_ticks(x);
-  const rclock::duration::days d{ticks};
-  const r_ssize size = d.size();
+weekday_from_time_point_cpp(cpp11::list_of<cpp11::doubles> x_fields) {
+  const rclock::duration::days x{x_fields};
+  const r_ssize size = x.size();
   cpp11::writable::integers out(size);
 
   for (r_ssize i = 0; i < size; ++i) {
-    if (d.is_na(i)) {
+    if (x.is_na(i)) {
       out[i] = r_int_na;
       continue;
     }
 
-    const date::sys_days sd{d[i]};
-    const date::weekday weekday{sd};
+    const date::sys_days elt{x[i]};
+    const date::weekday weekday{elt};
     out[i] = static_cast<int>(reencode_c_to_western(weekday.c_encoding()));
   }
 

--- a/tests/testthat/_snaps/duration.md
+++ b/tests/testthat/_snaps/duration.md
@@ -213,3 +213,61 @@
       ! Can't convert from `y` <double> to <integer> due to loss of precision.
       * Locations: 1
 
+# `NA` duration prints as expected
+
+    Code
+      duration_years(NA)
+    Output
+      <duration<year>[1]>
+      [1] NA
+    Code
+      duration_quarters(NA)
+    Output
+      <duration<quarter>[1]>
+      [1] NA
+    Code
+      duration_months(NA)
+    Output
+      <duration<month>[1]>
+      [1] NA
+    Code
+      duration_weeks(NA)
+    Output
+      <duration<week>[1]>
+      [1] NA
+    Code
+      duration_days(NA)
+    Output
+      <duration<day>[1]>
+      [1] NA
+    Code
+      duration_hours(NA)
+    Output
+      <duration<hour>[1]>
+      [1] NA
+    Code
+      duration_minutes(NA)
+    Output
+      <duration<minute>[1]>
+      [1] NA
+    Code
+      duration_seconds(NA)
+    Output
+      <duration<second>[1]>
+      [1] NA
+    Code
+      duration_milliseconds(NA)
+    Output
+      <duration<millisecond>[1]>
+      [1] NA
+    Code
+      duration_microseconds(NA)
+    Output
+      <duration<microsecond>[1]>
+      [1] NA
+    Code
+      duration_nanoseconds(NA)
+    Output
+      <duration<nanosecond>[1]>
+      [1] NA
+

--- a/tests/testthat/test-duration.R
+++ b/tests/testthat/test-duration.R
@@ -382,3 +382,40 @@ test_that("sign() propagates names", {
   x <- set_names(duration_years(1:2), c("a", "b"))
   expect_named(sign(x), c("a", "b"))
 })
+
+# ------------------------------------------------------------------------------
+# vec_order()
+
+test_that("ordering works", {
+  x <- duration_days(c(-1, -3, -2, 1))
+  expect_identical(vec_order(x), c(2L, 3L, 1L, 4L))
+})
+
+# ------------------------------------------------------------------------------
+# vec_compare()
+
+test_that("comparisons work", {
+  x <- duration_days(c(1, NA, 2))
+  y <- duration_days(c(0, 2, 3))
+  expect_identical(vec_compare(x, y), c(1L, NA, -1L))
+})
+
+# ------------------------------------------------------------------------------
+# Missing values
+
+test_that("`NA` duration prints as expected", {
+  expect_snapshot({
+    duration_years(NA)
+    duration_quarters(NA)
+    duration_months(NA)
+    duration_weeks(NA)
+    duration_days(NA)
+    duration_hours(NA)
+    duration_minutes(NA)
+    duration_seconds(NA)
+    duration_milliseconds(NA)
+    duration_microseconds(NA)
+    duration_nanoseconds(NA)
+  })
+})
+


### PR DESCRIPTION
Part of #280 

#280 is still a little complicated with sys-time, naive-time, and zoned-time. We can now represent the full range of an `int64_t` in these types, but they don't _print_ correctly because the print method used by date forces them through `year_month_day`, which has a year limit of +/-32767. 

Essentially, the _true_ range supported by time points and calendar types in date is the lower bound of what is supported by:
- `year_month_day`
- The time point type at a given `precision`

See `Range of validity` here which also outlines this, giving the following limits (on that particular computer):
https://howardhinnant.github.io/date/date.html#range

```
picoseconds range is     : [1969-09-16 05:57:07.963145224192, 1970-04-17 18:02:52.036854775807]
nanoseconds range is     : [1677-09-21 00:12:43.145224192, 2262-04-11 23:47:16.854775807]
VS system_clock range is : [-27258-04-19 21:11:54.5224192, 31197-09-14 02:48:05.4775807]
microseconds range is    : [-32768-01-01, 32767-12-31]
milliseconds range is    : [-32768-01-01, 32767-12-31]
seconds range is         : [-32768-01-01, 32767-12-31]
minutes range is         : [-2114-12-08 21:52, 6053-01-23 02:07]
hours range is           : [-32768-01-01, 32767-12-31]
```

Math within the time point types still works correctly even outside these ranges though. That is only limited by `int64_t`.

And durations aren't constrained by this at all since they don't use year-month-day for printing.

``` r
# Very wrong for time points, right for durations
new_duration_from_fields(list(lower = 0, upper = 0), PRECISION_MILLISECOND, NULL)
#> <duration<millisecond>[1]>
#> [1] -9223372036854775808
new_sys_time_from_fields(list(lower = 0, upper = 0), PRECISION_MILLISECOND, NULL)
#> <sys_time<millisecond>[1]>
#> [1] "1535-09-26T2547115198447:12:55.808"
new_duration_from_fields(list(lower = 4294967295, upper = 4294967295), PRECISION_MILLISECOND, NULL)
#> <duration<millisecond>[1]>
#> [1] 9223372036854775807
new_sys_time_from_fields(list(lower = 4294967295, upper = 4294967295), PRECISION_MILLISECOND, NULL)
#> <sys_time<millisecond>[1]>
#> [1] "2404-04-06T-2547115198423:12:55.809"

# This looks kind of right but is not for time points
new_duration_from_fields(list(lower = 0, upper = 0), PRECISION_MICROSECOND, NULL)
#> <duration<microsecond>[1]>
#> [1] -9223372036854775808
new_sys_time_from_fields(list(lower = 0, upper = 0), PRECISION_MICROSECOND, NULL)
#> <sys_time<microsecond>[1]>
#> [1] "-28164-12-21T19:59:05.224192"
new_duration_from_fields(list(lower = 4294967295, upper = 4294967295), PRECISION_MICROSECOND, NULL)
#> <duration<microsecond>[1]>
#> [1] 9223372036854775807
new_sys_time_from_fields(list(lower = 4294967295, upper = 4294967295), PRECISION_MICROSECOND, NULL)
#> <sys_time<microsecond>[1]>
#> [1] "32103-01-10T04:00:54.775807"

# This is right for both
new_duration_from_fields(list(lower = 0, upper = 0), PRECISION_NANOSECOND, NULL)
#> <duration<nanosecond>[1]>
#> [1] -9223372036854775808
new_sys_time_from_fields(list(lower = 0, upper = 0), PRECISION_NANOSECOND, NULL)
#> <sys_time<nanosecond>[1]>
#> [1] "1677-09-21T00:12:43.145224192"
new_duration_from_fields(list(lower = 4294967295, upper = 4294967295), PRECISION_NANOSECOND, NULL)
#> <duration<nanosecond>[1]>
#> [1] 9223372036854775807
new_sys_time_from_fields(list(lower = 4294967295, upper = 4294967295), PRECISION_NANOSECOND, NULL)
#> <sys_time<nanosecond>[1]>
#> [1] "2262-04-11T23:47:16.854775807"
```