### PR TITLE
Add `...` to all `as_*()` generics

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # clock (development version)
 
+* All `as_*()` generics exported by clock now include `...` in their signature
+  to help with extensibility of converting to clock types. These are the only
+  clock generics that are currently "blessed" as fully extensible (#348).
+
 * `%%` and `%/%` operators now return a missing value when the right-hand side
   is `0`. For `%/%`, this is consistent with `2L %/% 0L`, which returns a
   missing value, rather than with `2 %/% 0`, which returns `Inf`, since 

--- a/R/calendar.R
+++ b/R/calendar.R
@@ -1163,7 +1163,8 @@ as_year_month_day.clock_calendar <- function(x) {
 }
 
 #' @export
-as_year_month_weekday.clock_calendar <- function(x) {
+as_year_month_weekday.clock_calendar <- function(x, ...) {
+  check_dots_empty0(...)
   as_year_month_weekday(as_sys_time(x))
 }
 

--- a/R/calendar.R
+++ b/R/calendar.R
@@ -1181,7 +1181,8 @@ as_iso_year_week_day.clock_calendar <- function(x, ...) {
 }
 
 #' @export
-as_year_day.clock_calendar <- function(x) {
+as_year_day.clock_calendar <- function(x, ...) {
+  check_dots_empty0(...)
   as_year_day(as_sys_time(x))
 }
 

--- a/R/calendar.R
+++ b/R/calendar.R
@@ -1158,7 +1158,8 @@ arith_numeric_and_calendar <- function(op, x, y, ...) {
 # ------------------------------------------------------------------------------
 
 #' @export
-as_year_month_day.clock_calendar <- function(x) {
+as_year_month_day.clock_calendar <- function(x, ...) {
+  check_dots_empty0(...)
   as_year_month_day(as_sys_time(x))
 }
 

--- a/R/calendar.R
+++ b/R/calendar.R
@@ -1175,7 +1175,8 @@ as_year_week_day.clock_calendar <- function(x, ..., start = NULL) {
 }
 
 #' @export
-as_iso_year_week_day.clock_calendar <- function(x) {
+as_iso_year_week_day.clock_calendar <- function(x, ...) {
+  check_dots_empty0(...)
   as_iso_year_week_day(as_sys_time(x))
 }
 

--- a/R/calendar.R
+++ b/R/calendar.R
@@ -1188,7 +1188,8 @@ as_year_day.clock_calendar <- function(x, ...) {
 
 #' @export
 as_year_quarter_day.clock_calendar <- function(x, ..., start = NULL) {
-  as_year_quarter_day(as_sys_time(x), ..., start = start)
+  check_dots_empty0(...)
+  as_year_quarter_day(as_sys_time(x), start = start)
 }
 
 # ------------------------------------------------------------------------------

--- a/R/calendar.R
+++ b/R/calendar.R
@@ -1170,7 +1170,8 @@ as_year_month_weekday.clock_calendar <- function(x, ...) {
 
 #' @export
 as_year_week_day.clock_calendar <- function(x, ..., start = NULL) {
-  as_year_week_day(as_sys_time(x), ..., start = start)
+  check_dots_empty0(...)
+  as_year_week_day(as_sys_time(x), start = start)
 }
 
 #' @export

--- a/R/date.R
+++ b/R/date.R
@@ -95,7 +95,8 @@ as_year_week_day.Date <- function(x, ..., start = NULL) {
 }
 
 #' @export
-as_iso_year_week_day.Date <- function(x) {
+as_iso_year_week_day.Date <- function(x, ...) {
+  check_dots_empty0(...)
   as_iso_year_week_day(as_naive_time(x))
 }
 

--- a/R/date.R
+++ b/R/date.R
@@ -1,5 +1,6 @@
 #' @export
-as_sys_time.Date <- function(x) {
+as_sys_time.Date <- function(x, ...) {
+  check_dots_empty0(...)
   names <- names(x)
   x <- unstructure(x)
   if (is.double(x)) {

--- a/R/date.R
+++ b/R/date.R
@@ -74,7 +74,8 @@ as_zoned_time.Date <- function(x,
 }
 
 #' @export
-as_year_month_day.Date <- function(x) {
+as_year_month_day.Date <- function(x, ...) {
+  check_dots_empty0(...)
   as_year_month_day(as_naive_time(x))
 }
 

--- a/R/date.R
+++ b/R/date.R
@@ -86,7 +86,8 @@ as_year_month_weekday.Date <- function(x, ...) {
 
 #' @export
 as_year_quarter_day.Date <- function(x, ..., start = NULL) {
-  as_year_quarter_day(as_naive_time(x), ..., start = start)
+  check_dots_empty0(...)
+  as_year_quarter_day(as_naive_time(x), start = start)
 }
 
 #' @export

--- a/R/date.R
+++ b/R/date.R
@@ -108,7 +108,8 @@ as_year_day.Date <- function(x, ...) {
 }
 
 #' @export
-as_weekday.Date <- function(x) {
+as_weekday.Date <- function(x, ...) {
+  check_dots_empty0(...)
   as_weekday(as_naive_time(x))
 }
 

--- a/R/date.R
+++ b/R/date.R
@@ -66,8 +66,9 @@ as_zoned_time.Date <- function(x,
                                ...,
                                nonexistent = NULL,
                                ambiguous = NULL) {
+  check_dots_empty0(...)
   x <- as_naive_time(x)
-  as_zoned_time(x, zone = zone, ..., nonexistent = nonexistent, ambiguous = ambiguous)
+  as_zoned_time(x, zone = zone, nonexistent = nonexistent, ambiguous = ambiguous)
 }
 
 #' @export

--- a/R/date.R
+++ b/R/date.R
@@ -157,6 +157,8 @@ as.Date.clock_zoned_time <- function(x, ...) {
 #' [date_parse()]. For converting numerics to dates, see [vctrs::new_date()] or
 #' continue to use `as.Date()`.
 #'
+#' @inheritParams rlang::args_dots_empty
+#'
 #' @param x `[vector]`
 #'
 #'   A vector.
@@ -176,37 +178,42 @@ as.Date.clock_zoned_time <- function(x, ...) {
 #'
 #' # Can also convert from other clock types
 #' as_date(year_month_day(2019, 2, 5))
-as_date <- function(x) {
+as_date <- function(x, ...) {
   UseMethod("as_date")
 }
 
 #' @rdname as_date
 #' @export
-as_date.Date <- function(x) {
+as_date.Date <- function(x, ...) {
+  check_dots_empty0(...)
   date_standardize(x)
 }
 
 #' @rdname as_date
 #' @export
-as_date.POSIXt <- function(x) {
+as_date.POSIXt <- function(x, ...) {
+  check_dots_empty0(...)
   as.Date(as_naive_time(x))
 }
 
 #' @rdname as_date
 #' @export
-as_date.clock_calendar <- function(x) {
+as_date.clock_calendar <- function(x, ...) {
+  check_dots_empty0(...)
   as.Date(x)
 }
 
 #' @rdname as_date
 #' @export
-as_date.clock_time_point <- function(x) {
+as_date.clock_time_point <- function(x, ...) {
+  check_dots_empty0(...)
   as.Date(x)
 }
 
 #' @rdname as_date
 #' @export
-as_date.clock_zoned_time <- function(x) {
+as_date.clock_zoned_time <- function(x, ...) {
+  check_dots_empty0(...)
   as.Date(x)
 }
 

--- a/R/date.R
+++ b/R/date.R
@@ -101,7 +101,8 @@ as_iso_year_week_day.Date <- function(x, ...) {
 }
 
 #' @export
-as_year_day.Date <- function(x) {
+as_year_day.Date <- function(x, ...) {
+  check_dots_empty0(...)
   as_year_day(as_naive_time(x))
 }
 

--- a/R/date.R
+++ b/R/date.R
@@ -88,7 +88,8 @@ as_year_quarter_day.Date <- function(x, ..., start = NULL) {
 
 #' @export
 as_year_week_day.Date <- function(x, ..., start = NULL) {
-  as_year_week_day(as_naive_time(x), ..., start = start)
+  check_dots_empty0(...)
+  as_year_week_day(as_naive_time(x), start = start)
 }
 
 #' @export

--- a/R/date.R
+++ b/R/date.R
@@ -11,7 +11,8 @@ as_sys_time.Date <- function(x, ...) {
 }
 
 #' @export
-as_naive_time.Date <- function(x) {
+as_naive_time.Date <- function(x, ...) {
+  check_dots_empty0(...)
   as_naive_time(as_sys_time(x))
 }
 

--- a/R/date.R
+++ b/R/date.R
@@ -76,7 +76,8 @@ as_year_month_day.Date <- function(x) {
 }
 
 #' @export
-as_year_month_weekday.Date <- function(x) {
+as_year_month_weekday.Date <- function(x, ...) {
+  check_dots_empty0(...)
   as_year_month_weekday(as_naive_time(x))
 }
 

--- a/R/duration.R
+++ b/R/duration.R
@@ -313,7 +313,9 @@ as_duration.clock_duration <- function(x) {
 # ------------------------------------------------------------------------------
 
 #' @export
-as_sys_time.clock_duration <- function(x) {
+as_sys_time.clock_duration <- function(x, ...) {
+  check_dots_empty0(...)
+
   names <- clock_rcrd_names(x)
 
   # Promote to at least day precision for sys-time

--- a/R/duration.R
+++ b/R/duration.R
@@ -283,6 +283,8 @@ vec_cast.clock_duration.clock_duration <- function(x, to, ...) {
 #'
 #' To round an existing duration to another precision, see [duration_floor()].
 #'
+#' @inheritParams rlang::args_dots_empty
+#'
 #' @param x `[object]`
 #'
 #'   An object to convert to a duration.
@@ -301,12 +303,13 @@ vec_cast.clock_duration.clock_duration <- function(x, to, ...) {
 #'
 #' # The number of seconds since 1970-01-01 00:00:00 UTC
 #' as_duration(x)
-as_duration <- function(x) {
+as_duration <- function(x, ...) {
   UseMethod("as_duration")
 }
 
 #' @export
-as_duration.clock_duration <- function(x) {
+as_duration.clock_duration <- function(x, ...) {
+  check_dots_empty0(...)
   x
 }
 

--- a/R/duration.R
+++ b/R/duration.R
@@ -331,7 +331,8 @@ as_sys_time.clock_duration <- function(x, ...) {
 }
 
 #' @export
-as_naive_time.clock_duration <- function(x) {
+as_naive_time.clock_duration <- function(x, ...) {
+  check_dots_empty0(...)
   as_naive_time(as_sys_time(x))
 }
 

--- a/R/gregorian-year-day.R
+++ b/R/gregorian-year-day.R
@@ -752,7 +752,8 @@ as_year_day.clock_year_day <- function(x) {
 # ------------------------------------------------------------------------------
 
 #' @export
-as_sys_time.clock_year_day <- function(x) {
+as_sys_time.clock_year_day <- function(x, ...) {
+  check_dots_empty0(...)
   calendar_check_no_invalid(x)
   precision <- calendar_precision_attribute(x)
   fields <- as_sys_time_year_day_cpp(x, precision)

--- a/R/gregorian-year-day.R
+++ b/R/gregorian-year-day.R
@@ -720,6 +720,8 @@ year_day_plus_duration <- function(x,
 #' Time points, Dates, POSIXct, and other calendars can all be converted to
 #' year-day.
 #'
+#' @inheritParams rlang::args_dots_empty
+#'
 #' @param x `[vector]`
 #'
 #'   A vector to convert to year-day.
@@ -735,17 +737,18 @@ year_day_plus_duration <- function(x,
 #'
 #' # From other calendars
 #' as_year_day(year_quarter_day(2019, quarter = 2, day = 50))
-as_year_day <- function(x)  {
+as_year_day <- function(x, ...)  {
   UseMethod("as_year_day")
 }
 
 #' @export
-as_year_day.default <- function(x) {
+as_year_day.default <- function(x, ...) {
   stop_clock_unsupported_conversion(x, "clock_year_day")
 }
 
 #' @export
-as_year_day.clock_year_day <- function(x) {
+as_year_day.clock_year_day <- function(x, ...) {
+  check_dots_empty0(...)
   x
 }
 

--- a/R/gregorian-year-day.R
+++ b/R/gregorian-year-day.R
@@ -764,7 +764,8 @@ as_sys_time.clock_year_day <- function(x, ...) {
 }
 
 #' @export
-as_naive_time.clock_year_day <- function(x) {
+as_naive_time.clock_year_day <- function(x, ...) {
+  check_dots_empty0(...)
   as_naive_time(as_sys_time(x))
 }
 

--- a/R/gregorian-year-month-day.R
+++ b/R/gregorian-year-month-day.R
@@ -1028,7 +1028,8 @@ as_year_month_day.clock_year_month_day <- function(x) {
 # ------------------------------------------------------------------------------
 
 #' @export
-as_sys_time.clock_year_month_day <- function(x) {
+as_sys_time.clock_year_month_day <- function(x, ...) {
+  check_dots_empty0(...)
   calendar_check_no_invalid(x)
   precision <- calendar_precision_attribute(x)
   fields <- as_sys_time_year_month_day_cpp(x, precision)

--- a/R/gregorian-year-month-day.R
+++ b/R/gregorian-year-month-day.R
@@ -1037,7 +1037,8 @@ as_sys_time.clock_year_month_day <- function(x, ...) {
 }
 
 #' @export
-as_naive_time.clock_year_month_day <- function(x) {
+as_naive_time.clock_year_month_day <- function(x, ...) {
+  check_dots_empty0(...)
   as_naive_time(as_sys_time(x))
 }
 

--- a/R/gregorian-year-month-day.R
+++ b/R/gregorian-year-month-day.R
@@ -996,6 +996,8 @@ year_month_day_plus_duration <- function(x,
 #' Time points, Dates, POSIXct, and other calendars can all be converted to
 #' year-month-day.
 #'
+#' @inheritParams rlang::args_dots_empty
+#'
 #' @param x `[vector]`
 #'
 #'   A vector to convert to year-month-day.
@@ -1011,17 +1013,18 @@ year_month_day_plus_duration <- function(x,
 #'
 #' # From other calendars
 #' as_year_month_day(year_quarter_day(2019, quarter = 2, day = 50))
-as_year_month_day <- function(x)  {
+as_year_month_day <- function(x, ...)  {
   UseMethod("as_year_month_day")
 }
 
 #' @export
-as_year_month_day.default <- function(x) {
+as_year_month_day.default <- function(x, ...) {
   stop_clock_unsupported_conversion(x, "clock_year_month_day")
 }
 
 #' @export
-as_year_month_day.clock_year_month_day <- function(x) {
+as_year_month_day.clock_year_month_day <- function(x, ...) {
+  check_dots_empty0(...)
   x
 }
 

--- a/R/gregorian-year-month-weekday.R
+++ b/R/gregorian-year-month-weekday.R
@@ -918,7 +918,8 @@ as_year_month_weekday.clock_year_month_weekday <- function(x, ...) {
 # ------------------------------------------------------------------------------
 
 #' @export
-as_sys_time.clock_year_month_weekday <- function(x) {
+as_sys_time.clock_year_month_weekday <- function(x, ...) {
+  check_dots_empty0(...)
   calendar_check_no_invalid(x)
   precision <- calendar_precision_attribute(x)
   fields <- as_sys_time_year_month_weekday_cpp(x, precision)

--- a/R/gregorian-year-month-weekday.R
+++ b/R/gregorian-year-month-weekday.R
@@ -883,6 +883,8 @@ year_month_weekday_plus_duration <- function(x,
 #' calendar. Time points, Dates, POSIXct, and other calendars can all be
 #' converted to year-month-weekday.
 #'
+#' @inheritParams rlang::args_dots_empty
+#'
 #' @param x `[vector]`
 #'
 #'   A vector to convert to year-month-weekday.
@@ -898,17 +900,18 @@ year_month_weekday_plus_duration <- function(x,
 #'
 #' # From other calendars
 #' as_year_month_weekday(year_quarter_day(2019, quarter = 2, day = 50))
-as_year_month_weekday <- function(x)  {
+as_year_month_weekday <- function(x, ...)  {
   UseMethod("as_year_month_weekday")
 }
 
 #' @export
-as_year_month_weekday.default <- function(x) {
+as_year_month_weekday.default <- function(x, ...) {
   stop_clock_unsupported_conversion(x, "clock_year_month_weekday")
 }
 
 #' @export
-as_year_month_weekday.clock_year_month_weekday <- function(x) {
+as_year_month_weekday.clock_year_month_weekday <- function(x, ...) {
+  check_dots_empty0(...)
   x
 }
 

--- a/R/gregorian-year-month-weekday.R
+++ b/R/gregorian-year-month-weekday.R
@@ -927,7 +927,8 @@ as_sys_time.clock_year_month_weekday <- function(x, ...) {
 }
 
 #' @export
-as_naive_time.clock_year_month_weekday <- function(x) {
+as_naive_time.clock_year_month_weekday <- function(x, ...) {
+  check_dots_empty0(...)
   as_naive_time(as_sys_time(x))
 }
 

--- a/R/iso-year-week-day.R
+++ b/R/iso-year-week-day.R
@@ -785,7 +785,8 @@ as_iso_year_week_day.clock_iso_year_week_day <- function(x) {
 # ------------------------------------------------------------------------------
 
 #' @export
-as_sys_time.clock_iso_year_week_day <- function(x) {
+as_sys_time.clock_iso_year_week_day <- function(x, ...) {
+  check_dots_empty0(...)
   calendar_check_no_invalid(x)
   precision <- calendar_precision_attribute(x)
   fields <- as_sys_time_iso_year_week_day_cpp(x, precision)

--- a/R/iso-year-week-day.R
+++ b/R/iso-year-week-day.R
@@ -753,6 +753,8 @@ iso_year_week_day_plus_duration <- function(x,
 #' calendar. Time points, Dates, POSIXct, and other calendars can all be
 #' converted to iso-year-week-day.
 #'
+#' @inheritParams rlang::args_dots_empty
+#'
 #' @param x `[vector]`
 #'
 #'   A vector to convert to iso-year-week-day.
@@ -768,17 +770,18 @@ iso_year_week_day_plus_duration <- function(x,
 #'
 #' # From other calendars
 #' as_iso_year_week_day(year_quarter_day(2019, quarter = 2, day = 50))
-as_iso_year_week_day <- function(x)  {
+as_iso_year_week_day <- function(x, ...)  {
   UseMethod("as_iso_year_week_day")
 }
 
 #' @export
-as_iso_year_week_day.default <- function(x) {
+as_iso_year_week_day.default <- function(x, ...) {
   stop_clock_unsupported_conversion(x, "clock_iso_year_week_day")
 }
 
 #' @export
-as_iso_year_week_day.clock_iso_year_week_day <- function(x) {
+as_iso_year_week_day.clock_iso_year_week_day <- function(x, ...) {
+  check_dots_empty0(...)
   x
 }
 

--- a/R/iso-year-week-day.R
+++ b/R/iso-year-week-day.R
@@ -797,7 +797,8 @@ as_sys_time.clock_iso_year_week_day <- function(x, ...) {
 }
 
 #' @export
-as_naive_time.clock_iso_year_week_day <- function(x) {
+as_naive_time.clock_iso_year_week_day <- function(x, ...) {
+  check_dots_empty0(...)
   as_naive_time(as_sys_time(x))
 }
 

--- a/R/naive-time.R
+++ b/R/naive-time.R
@@ -153,6 +153,8 @@ naive_time_parse <- function(x,
 #' native date and date-time types. Like converting from a zoned-time, these
 #' retain the printed time.
 #'
+#' @inheritParams rlang::args_dots_empty
+#'
 #' @param x `[object]`
 #'
 #'   An object to convert to a naive-time.
@@ -171,17 +173,18 @@ naive_time_parse <- function(x,
 #'
 #' ymd <- set_day(ym, 10)
 #' as_naive_time(ymd)
-as_naive_time <- function(x) {
+as_naive_time <- function(x, ...) {
   UseMethod("as_naive_time")
 }
 
 #' @export
-as_naive_time.default <- function(x) {
+as_naive_time.default <- function(x, ...) {
   stop_clock_unsupported(x)
 }
 
 #' @export
-as_naive_time.clock_naive_time <- function(x) {
+as_naive_time.clock_naive_time <- function(x, ...) {
+  check_dots_empty0(...)
   x
 }
 

--- a/R/naive-time.R
+++ b/R/naive-time.R
@@ -188,7 +188,8 @@ as_naive_time.clock_naive_time <- function(x) {
 # ------------------------------------------------------------------------------
 
 #' @export
-as_sys_time.clock_naive_time <- function(x) {
+as_sys_time.clock_naive_time <- function(x, ...) {
+  check_dots_empty0(...)
   new_sys_time_from_fields(x, time_point_precision_attribute(x), clock_rcrd_names(x))
 }
 

--- a/R/posixt.R
+++ b/R/posixt.R
@@ -6,7 +6,8 @@ as_sys_time.POSIXt <- function(x, ...) {
 }
 
 #' @export
-as_naive_time.POSIXt <- function(x) {
+as_naive_time.POSIXt <- function(x, ...) {
+  check_dots_empty0(...)
   as_naive_time(as_zoned_time(x))
 }
 

--- a/R/posixt.R
+++ b/R/posixt.R
@@ -1,6 +1,7 @@
 #' @export
-as_sys_time.POSIXt <- function(x) {
+as_sys_time.POSIXt <- function(x, ...) {
   # The sys-time that would give the equivalent zoned-time when a zone is attached
+  check_dots_empty0(...)
   as_sys_time(as_zoned_time(x))
 }
 

--- a/R/posixt.R
+++ b/R/posixt.R
@@ -76,8 +76,9 @@ as_year_week_day.POSIXt <- function(x, ..., start = NULL) {
 }
 
 #' @export
-as_iso_year_week_day.POSIXt <- function(x) {
+as_iso_year_week_day.POSIXt <- function(x, ...) {
   # Assumes zoned -> naive -> calendar is what the user expects
+  check_dots_empty0(...)
   x <- as_naive_time(x)
   as_iso_year_week_day(x)
 }

--- a/R/posixt.R
+++ b/R/posixt.R
@@ -46,8 +46,9 @@ as_zoned_time.POSIXt <- function(x, ...) {
 }
 
 #' @export
-as_year_month_day.POSIXt <- function(x) {
+as_year_month_day.POSIXt <- function(x, ...) {
   # Assumes zoned -> naive -> calendar is what the user expects
+  check_dots_empty0(...)
   x <- as_naive_time(x)
   as_year_month_day(x)
 }

--- a/R/posixt.R
+++ b/R/posixt.R
@@ -93,8 +93,9 @@ as_year_day.POSIXt <- function(x, ...) {
 }
 
 #' @export
-as_weekday.POSIXt <- function(x) {
+as_weekday.POSIXt <- function(x, ...) {
   # Assumes zoned -> naive is what the user expects
+  check_dots_empty0(...)
   x <- as_naive_time(x)
   as_weekday(x)
 }

--- a/R/posixt.R
+++ b/R/posixt.R
@@ -84,8 +84,9 @@ as_iso_year_week_day.POSIXt <- function(x, ...) {
 }
 
 #' @export
-as_year_day.POSIXt <- function(x) {
+as_year_day.POSIXt <- function(x, ...) {
   # Assumes zoned -> naive -> calendar is what the user expects
+  check_dots_empty0(...)
   x <- as_naive_time(x)
   as_year_day(x)
 }

--- a/R/posixt.R
+++ b/R/posixt.R
@@ -51,8 +51,9 @@ as_year_month_day.POSIXt <- function(x) {
 }
 
 #' @export
-as_year_month_weekday.POSIXt <- function(x) {
+as_year_month_weekday.POSIXt <- function(x, ...) {
   # Assumes zoned -> naive -> calendar is what the user expects
+  check_dots_empty0(...)
   x <- as_naive_time(x)
   as_year_month_weekday(x)
 }

--- a/R/quarterly-year-quarter-day.R
+++ b/R/quarterly-year-quarter-day.R
@@ -930,7 +930,8 @@ as_sys_time.clock_year_quarter_day <- function(x, ...) {
 }
 
 #' @export
-as_naive_time.clock_year_quarter_day <- function(x) {
+as_naive_time.clock_year_quarter_day <- function(x, ...) {
+  check_dots_empty0(...)
   as_naive_time(as_sys_time(x))
 }
 

--- a/R/quarterly-year-quarter-day.R
+++ b/R/quarterly-year-quarter-day.R
@@ -920,7 +920,8 @@ as_year_quarter_day.clock_year_quarter_day <- function(x, ..., start = NULL) {
 # ------------------------------------------------------------------------------
 
 #' @export
-as_sys_time.clock_year_quarter_day <- function(x) {
+as_sys_time.clock_year_quarter_day <- function(x, ...) {
+  check_dots_empty0(...)
   calendar_check_no_invalid(x)
   start <- quarterly_start(x)
   precision <- calendar_precision_attribute(x)

--- a/R/quarterly-year-quarter-day.R
+++ b/R/quarterly-year-quarter-day.R
@@ -901,7 +901,7 @@ as_year_quarter_day.default <- function(x, ..., start = NULL) {
 
 #' @export
 as_year_quarter_day.clock_year_quarter_day <- function(x, ..., start = NULL) {
-  check_dots_empty()
+  check_dots_empty0(...)
 
   if (is_null(start)) {
     return(x)

--- a/R/sys-time.R
+++ b/R/sys-time.R
@@ -336,7 +336,8 @@ as_sys_time.clock_sys_time <- function(x, ...) {
 # ------------------------------------------------------------------------------
 
 #' @export
-as_naive_time.clock_sys_time <- function(x) {
+as_naive_time.clock_sys_time <- function(x, ...) {
+  check_dots_empty0(...)
   new_naive_time_from_fields(x, time_point_precision_attribute(x), clock_rcrd_names(x))
 }
 

--- a/R/sys-time.R
+++ b/R/sys-time.R
@@ -288,6 +288,8 @@ is_valid_RFC_3339_precision <- function(precision) {
 #' retain the underlying duration, but will change the printed time if the
 #' zone was not already UTC.
 #'
+#' @inheritParams rlang::args_dots_empty
+#'
 #' @param x `[object]`
 #'
 #'   An object to convert to a sys-time.
@@ -316,17 +318,18 @@ is_valid_RFC_3339_precision <- function(precision) {
 #'
 #' ymd <- set_day(ym, 10)
 #' as_sys_time(ymd)
-as_sys_time <- function(x) {
+as_sys_time <- function(x, ...) {
   UseMethod("as_sys_time")
 }
 
 #' @export
-as_sys_time.default <- function(x) {
+as_sys_time.default <- function(x, ...) {
   stop_clock_unsupported(x)
 }
 
 #' @export
-as_sys_time.clock_sys_time <- function(x) {
+as_sys_time.clock_sys_time <- function(x, ...) {
+  check_dots_empty0(...)
   x
 }
 

--- a/R/time-point.R
+++ b/R/time-point.R
@@ -531,7 +531,8 @@ as_year_week_day.clock_time_point <- function(x, ..., start = NULL) {
 }
 
 #' @export
-as_iso_year_week_day.clock_time_point <- function(x) {
+as_iso_year_week_day.clock_time_point <- function(x, ...) {
+  check_dots_empty0(...)
   precision <- time_point_precision_attribute(x)
   fields <- as_iso_year_week_day_from_sys_time_cpp(x, precision)
   new_iso_year_week_day_from_fields(fields, precision, names = names(x))

--- a/R/time-point.R
+++ b/R/time-point.R
@@ -515,7 +515,7 @@ as_year_month_weekday.clock_time_point <- function(x, ...) {
 
 #' @export
 as_year_quarter_day.clock_time_point <- function(x, ..., start = NULL) {
-  check_dots_empty()
+  check_dots_empty0(...)
   precision <- time_point_precision_attribute(x)
   start <- quarterly_validate_start(start)
   fields <- as_year_quarter_day_from_sys_time_cpp(x, precision, start)

--- a/R/time-point.R
+++ b/R/time-point.R
@@ -493,7 +493,8 @@ add_months.clock_time_point <- function(x, n, ...) {
 # ------------------------------------------------------------------------------
 
 #' @export
-as_duration.clock_time_point <- function(x) {
+as_duration.clock_time_point <- function(x, ...) {
+  check_dots_empty0(...)
   time_point_duration(x, retain_names = TRUE)
 }
 

--- a/R/time-point.R
+++ b/R/time-point.R
@@ -540,7 +540,8 @@ as_iso_year_week_day.clock_time_point <- function(x, ...) {
 }
 
 #' @export
-as_year_day.clock_time_point <- function(x) {
+as_year_day.clock_time_point <- function(x, ...) {
+  check_dots_empty0(...)
   precision <- time_point_precision_attribute(x)
   fields <- as_year_day_from_sys_time_cpp(x, precision)
   new_year_day_from_fields(fields, precision, names = names(x))

--- a/R/time-point.R
+++ b/R/time-point.R
@@ -505,7 +505,8 @@ as_year_month_day.clock_time_point <- function(x) {
 }
 
 #' @export
-as_year_month_weekday.clock_time_point <- function(x) {
+as_year_month_weekday.clock_time_point <- function(x, ...) {
+  check_dots_empty0(...)
   precision <- time_point_precision_attribute(x)
   fields <- as_year_month_weekday_from_sys_time_cpp(x, precision)
   new_year_month_weekday_from_fields(fields, precision, names = names(x))

--- a/R/time-point.R
+++ b/R/time-point.R
@@ -523,6 +523,7 @@ as_year_quarter_day.clock_time_point <- function(x, ..., start = NULL) {
 
 #' @export
 as_year_week_day.clock_time_point <- function(x, ..., start = NULL) {
+  check_dots_empty0(...)
   precision <- time_point_precision_attribute(x)
   start <- week_validate_start(start)
   fields <- as_year_week_day_from_sys_time_cpp(x, precision, start)

--- a/R/time-point.R
+++ b/R/time-point.R
@@ -499,7 +499,8 @@ as_duration.clock_time_point <- function(x, ...) {
 }
 
 #' @export
-as_year_month_day.clock_time_point <- function(x) {
+as_year_month_day.clock_time_point <- function(x, ...) {
+  check_dots_empty0(...)
   precision <- time_point_precision_attribute(x)
   fields <- as_year_month_day_from_sys_time_cpp(x, precision)
   new_year_month_day_from_fields(fields, precision, names = names(x))

--- a/R/time-point.R
+++ b/R/time-point.R
@@ -548,7 +548,8 @@ as_year_day.clock_time_point <- function(x, ...) {
 }
 
 #' @export
-as_weekday.clock_time_point <- function(x) {
+as_weekday.clock_time_point <- function(x, ...) {
+  check_dots_empty0(...)
   x <- time_point_cast(x, "day")
   day <- weekday_from_time_point_cpp(x)
   names(day) <- clock_rcrd_names(x)

--- a/R/week-year-week-day.R
+++ b/R/week-year-week-day.R
@@ -873,7 +873,8 @@ as_sys_time.clock_year_week_day <- function(x, ...) {
 }
 
 #' @export
-as_naive_time.clock_year_week_day <- function(x) {
+as_naive_time.clock_year_week_day <- function(x, ...) {
+  check_dots_empty0(...)
   as_naive_time(as_sys_time(x))
 }
 

--- a/R/week-year-week-day.R
+++ b/R/week-year-week-day.R
@@ -844,7 +844,7 @@ as_year_week_day.default <- function(x, ..., start = NULL) {
 
 #' @export
 as_year_week_day.clock_year_week_day <- function(x, ..., start = NULL) {
-  check_dots_empty()
+  check_dots_empty0(...)
 
   if (is_null(start)) {
     return(x)

--- a/R/week-year-week-day.R
+++ b/R/week-year-week-day.R
@@ -863,7 +863,8 @@ as_year_week_day.clock_year_week_day <- function(x, ..., start = NULL) {
 # ------------------------------------------------------------------------------
 
 #' @export
-as_sys_time.clock_year_week_day <- function(x) {
+as_sys_time.clock_year_week_day <- function(x, ...) {
+  check_dots_empty0(...)
   calendar_check_no_invalid(x)
   start <- week_start(x)
   precision <- calendar_precision_attribute(x)

--- a/R/weekday.R
+++ b/R/weekday.R
@@ -190,6 +190,8 @@ vec_proxy_compare.clock_weekday <- function(x, ...) {
 #' function along with the _circular arithmetic_ that weekday implements to
 #' easily get to the "next Monday" or "previous Sunday".
 #'
+#' @inheritParams rlang::args_dots_empty
+#'
 #' @param x `[object]`
 #'
 #'   An object to convert to a weekday. Usually a sys-time or naive-time.
@@ -204,17 +206,18 @@ vec_proxy_compare.clock_weekday <- function(x, ...) {
 #' as_weekday(x)
 #'
 #' # See the examples in `?weekday` for more usage.
-as_weekday <- function(x) {
+as_weekday <- function(x, ...) {
   UseMethod("as_weekday")
 }
 
 #' @export
-as_weekday.clock_weekday <- function(x) {
+as_weekday.clock_weekday <- function(x, ...) {
+  check_dots_empty0(...)
   x
 }
 
 #' @export
-as_weekday.clock_calendar <- function(x) {
+as_weekday.clock_calendar <- function(x, ...) {
   abort(c(
     "Can't extract the weekday from a calendar.",
     i = "Do you need to convert to a time point first?"

--- a/R/zoned-time.R
+++ b/R/zoned-time.R
@@ -877,7 +877,8 @@ as_sys_time.clock_zoned_time <- function(x, ...) {
 }
 
 #' @export
-as_naive_time.clock_zoned_time <- function(x) {
+as_naive_time.clock_zoned_time <- function(x, ...) {
+  check_dots_empty0(...)
   names <- clock_rcrd_names(x)
   zone <- zoned_time_zone_attribute(x)
   precision <- zoned_time_precision_attribute(x)

--- a/R/zoned-time.R
+++ b/R/zoned-time.R
@@ -862,6 +862,7 @@ as_zoned_time.default <- function(x, ...) {
 
 #' @export
 as_zoned_time.clock_zoned_time <- function(x, ...) {
+  check_dots_empty0(...)
   x
 }
 

--- a/R/zoned-time.R
+++ b/R/zoned-time.R
@@ -869,7 +869,8 @@ as_zoned_time.clock_zoned_time <- function(x, ...) {
 # ------------------------------------------------------------------------------
 
 #' @export
-as_sys_time.clock_zoned_time <- function(x) {
+as_sys_time.clock_zoned_time <- function(x, ...) {
+  check_dots_empty0(...)
   names <- clock_rcrd_names(x)
   precision <- zoned_time_precision_attribute(x)
   new_sys_time_from_fields(x, precision, names)

--- a/man/as_date.Rd
+++ b/man/as_date.Rd
@@ -9,22 +9,24 @@
 \alias{as_date.clock_zoned_time}
 \title{Convert to a date}
 \usage{
-as_date(x)
+as_date(x, ...)
 
-\method{as_date}{Date}(x)
+\method{as_date}{Date}(x, ...)
 
-\method{as_date}{POSIXt}(x)
+\method{as_date}{POSIXt}(x, ...)
 
-\method{as_date}{clock_calendar}(x)
+\method{as_date}{clock_calendar}(x, ...)
 
-\method{as_date}{clock_time_point}(x)
+\method{as_date}{clock_time_point}(x, ...)
 
-\method{as_date}{clock_zoned_time}(x)
+\method{as_date}{clock_zoned_time}(x, ...)
 }
 \arguments{
 \item{x}{\verb{[vector]}
 
 A vector.}
+
+\item{...}{These dots are for future extensions and must be empty.}
 }
 \value{
 A date with the same length as \code{x}.

--- a/man/as_duration.Rd
+++ b/man/as_duration.Rd
@@ -4,12 +4,14 @@
 \alias{as_duration}
 \title{Convert to a duration}
 \usage{
-as_duration(x)
+as_duration(x, ...)
 }
 \arguments{
 \item{x}{\verb{[object]}
 
 An object to convert to a duration.}
+
+\item{...}{These dots are for future extensions and must be empty.}
 }
 \value{
 A duration with the same precision as \code{x}.

--- a/man/as_iso_year_week_day.Rd
+++ b/man/as_iso_year_week_day.Rd
@@ -4,12 +4,14 @@
 \alias{as_iso_year_week_day}
 \title{Convert to iso-year-week-day}
 \usage{
-as_iso_year_week_day(x)
+as_iso_year_week_day(x, ...)
 }
 \arguments{
 \item{x}{\verb{[vector]}
 
 A vector to convert to iso-year-week-day.}
+
+\item{...}{These dots are for future extensions and must be empty.}
 }
 \value{
 A iso-year-week-day vector.

--- a/man/as_naive_time.Rd
+++ b/man/as_naive_time.Rd
@@ -4,12 +4,14 @@
 \alias{as_naive_time}
 \title{Convert to a naive-time}
 \usage{
-as_naive_time(x)
+as_naive_time(x, ...)
 }
 \arguments{
 \item{x}{\verb{[object]}
 
 An object to convert to a naive-time.}
+
+\item{...}{These dots are for future extensions and must be empty.}
 }
 \value{
 A naive-time vector.

--- a/man/as_sys_time.Rd
+++ b/man/as_sys_time.Rd
@@ -4,12 +4,14 @@
 \alias{as_sys_time}
 \title{Convert to a sys-time}
 \usage{
-as_sys_time(x)
+as_sys_time(x, ...)
 }
 \arguments{
 \item{x}{\verb{[object]}
 
 An object to convert to a sys-time.}
+
+\item{...}{These dots are for future extensions and must be empty.}
 }
 \value{
 A sys-time vector.

--- a/man/as_weekday.Rd
+++ b/man/as_weekday.Rd
@@ -4,12 +4,14 @@
 \alias{as_weekday}
 \title{Convert to a weekday}
 \usage{
-as_weekday(x)
+as_weekday(x, ...)
 }
 \arguments{
 \item{x}{\verb{[object]}
 
 An object to convert to a weekday. Usually a sys-time or naive-time.}
+
+\item{...}{These dots are for future extensions and must be empty.}
 }
 \value{
 A weekday.

--- a/man/as_year_day.Rd
+++ b/man/as_year_day.Rd
@@ -4,12 +4,14 @@
 \alias{as_year_day}
 \title{Convert to year-day}
 \usage{
-as_year_day(x)
+as_year_day(x, ...)
 }
 \arguments{
 \item{x}{\verb{[vector]}
 
 A vector to convert to year-day.}
+
+\item{...}{These dots are for future extensions and must be empty.}
 }
 \value{
 A year-day vector.

--- a/man/as_year_month_day.Rd
+++ b/man/as_year_month_day.Rd
@@ -4,12 +4,14 @@
 \alias{as_year_month_day}
 \title{Convert to year-month-day}
 \usage{
-as_year_month_day(x)
+as_year_month_day(x, ...)
 }
 \arguments{
 \item{x}{\verb{[vector]}
 
 A vector to convert to year-month-day.}
+
+\item{...}{These dots are for future extensions and must be empty.}
 }
 \value{
 A year-month-day vector.

--- a/man/as_year_month_weekday.Rd
+++ b/man/as_year_month_weekday.Rd
@@ -4,12 +4,14 @@
 \alias{as_year_month_weekday}
 \title{Convert to year-month-weekday}
 \usage{
-as_year_month_weekday(x)
+as_year_month_weekday(x, ...)
 }
 \arguments{
 \item{x}{\verb{[vector]}
 
 A vector to convert to year-month-weekday.}
+
+\item{...}{These dots are for future extensions and must be empty.}
 }
 \value{
 A year-month-weekday vector.


### PR DESCRIPTION
Closes #348

Currently these are the only clock generics that I am super happy with as being fully extensible 