### PR TITLE
Use constructor defaults to fix `constexpr` issues

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # clock (development version)
 
+* Fixed an issue where clock would not compile on Centos 7 using gcc-5.4.0 due
+  to a `constexpr` issue (#357).
+
 * Fixed a test that failed due to `seq.Date()` now returning integer storage in
   some cases in the development version of R.
 

--- a/src/quarterly-shim.h
+++ b/src/quarterly-shim.h
@@ -251,7 +251,7 @@ year::is_leap() const NOEXCEPT {
   case start::october: return to_quarterly<start::october>(*this).is_leap();
   case start::november: return to_quarterly<start::november>(*this).is_leap();
   case start::december: return to_quarterly<start::december>(*this).is_leap();
-  default: throw std::runtime_error("[[unreachable]]");
+  default: return /* unreachable */ false;
   }
 }
 
@@ -277,7 +277,7 @@ operator+(const year& x, const quarterly::years& y) NOEXCEPT
   case start::october: return from_quarterly(to_quarterly<start::october>(x) + y);
   case start::november: return from_quarterly(to_quarterly<start::november>(x) + y);
   case start::december: return from_quarterly(to_quarterly<start::december>(x) + y);
-  default: throw std::runtime_error("[[unreachable]]");
+  default: return /* unreachable */ year();
   }
 }
 
@@ -303,7 +303,7 @@ operator-(const year& x, const year& y) NOEXCEPT
   case start::october: return to_quarterly<start::october>(x) - to_quarterly<start::october>(y);
   case start::november: return to_quarterly<start::november>(x) - to_quarterly<start::november>(y);
   case start::december: return to_quarterly<start::december>(x) - to_quarterly<start::december>(y);
-  default: throw std::runtime_error("[[unreachable]]");
+  default: return /* unreachable */ quarterly::years();
   }
 }
 
@@ -355,7 +355,7 @@ operator+(const year_quarternum& yqn, const quarterly::quarters& dq) NOEXCEPT
   case start::october: return from_quarterly(to_quarterly<start::october>(yqn) + dq);
   case start::november: return from_quarterly(to_quarterly<start::november>(yqn) + dq);
   case start::december: return from_quarterly(to_quarterly<start::december>(yqn) + dq);
-  default: throw std::runtime_error("[[unreachable]]");
+  default: return /* unreachable */ year_quarternum();
   }
 }
 
@@ -381,7 +381,7 @@ operator-(const year_quarternum& x, const year_quarternum& y) NOEXCEPT
   case start::october: return to_quarterly<start::october>(x) - to_quarterly<start::october>(y);
   case start::november: return to_quarterly<start::november>(x) - to_quarterly<start::november>(y);
   case start::december: return to_quarterly<start::december>(x) - to_quarterly<start::december>(y);
-  default: throw std::runtime_error("[[unreachable]]");
+  default: return /* unreachable */ quarterly::quarters();
   }
 }
 
@@ -446,7 +446,7 @@ year_quarternum_quarterday::from_sys_days(const date::sys_days& dp, quarterly::s
   case start::october: return from_quarterly(quarterly::year_quarternum_quarterday<start::october>(dp));
   case start::november: return from_quarterly(quarterly::year_quarternum_quarterday<start::november>(dp));
   case start::december: return from_quarterly(quarterly::year_quarternum_quarterday<start::december>(dp));
-  default: throw std::runtime_error("[[unreachable]]");
+  default: return /* unreachable */ year_quarternum_quarterday();
   }
 }
 
@@ -501,7 +501,7 @@ year_quarternum_quarterday::operator date::sys_days() const NOEXCEPT
   case start::october: return to_quarterly<start::october>(*this);
   case start::november: return to_quarterly<start::november>(*this);
   case start::december: return to_quarterly<start::december>(*this);
-  default: throw std::runtime_error("[[unreachable]]");
+  default: return /* unreachable */ date::sys_days();
   }
 }
 
@@ -525,7 +525,7 @@ year_quarternum_quarterday::operator date::local_days() const NOEXCEPT
   case start::october: return date::local_days(to_quarterly<start::october>(*this));
   case start::november: return date::local_days(to_quarterly<start::november>(*this));
   case start::december: return date::local_days(to_quarterly<start::december>(*this));
-  default: throw std::runtime_error("[[unreachable]]");
+  default: return /* unreachable */ date::local_days();
   }
 }
 
@@ -550,7 +550,7 @@ year_quarternum_quarterday::ok() const NOEXCEPT
   case start::october: return to_quarterly<start::october>(*this).ok();
   case start::november: return to_quarterly<start::november>(*this).ok();
   case start::december: return to_quarterly<start::december>(*this).ok();
-  default: throw std::runtime_error("[[unreachable]]");
+  default: return /* unreachable */ false;
   }
 }
 
@@ -608,7 +608,7 @@ year_quarternum_quarterday_last::quarterday() const NOEXCEPT
   case start::october: return to_quarterly<start::october>(*this).quarterday();
   case start::november: return to_quarterly<start::november>(*this).quarterday();
   case start::december: return to_quarterly<start::december>(*this).quarterday();
-  default: throw std::runtime_error("[[unreachable]]");
+  default: return /* unreachable */ quarterly::quarterday();
   }
 }
 

--- a/src/quarterly-shim.h
+++ b/src/quarterly-shim.h
@@ -133,19 +133,6 @@ public:
 
 namespace detail {
 
-static
-inline
-void
-never_reached [[noreturn]] () {
-  // Compiler hint to allow [[noreturn]] attribute. This is never executed since
-  // `never_reached()` is never actually called.
-  throw std::runtime_error("[[noreturn]]");
-}
-
-} // namespace detail
-
-namespace detail {
-
 template <quarterly::start S>
 CONSTCD14
 inline
@@ -264,7 +251,7 @@ year::is_leap() const NOEXCEPT {
   case start::october: return to_quarterly<start::october>(*this).is_leap();
   case start::november: return to_quarterly<start::november>(*this).is_leap();
   case start::december: return to_quarterly<start::december>(*this).is_leap();
-  default: detail::never_reached();
+  default: throw std::runtime_error("[[unreachable]]");
   }
 }
 
@@ -290,7 +277,7 @@ operator+(const year& x, const quarterly::years& y) NOEXCEPT
   case start::october: return from_quarterly(to_quarterly<start::october>(x) + y);
   case start::november: return from_quarterly(to_quarterly<start::november>(x) + y);
   case start::december: return from_quarterly(to_quarterly<start::december>(x) + y);
-  default: detail::never_reached();
+  default: throw std::runtime_error("[[unreachable]]");
   }
 }
 
@@ -316,7 +303,7 @@ operator-(const year& x, const year& y) NOEXCEPT
   case start::october: return to_quarterly<start::october>(x) - to_quarterly<start::october>(y);
   case start::november: return to_quarterly<start::november>(x) - to_quarterly<start::november>(y);
   case start::december: return to_quarterly<start::december>(x) - to_quarterly<start::december>(y);
-  default: detail::never_reached();
+  default: throw std::runtime_error("[[unreachable]]");
   }
 }
 
@@ -368,7 +355,7 @@ operator+(const year_quarternum& yqn, const quarterly::quarters& dq) NOEXCEPT
   case start::october: return from_quarterly(to_quarterly<start::october>(yqn) + dq);
   case start::november: return from_quarterly(to_quarterly<start::november>(yqn) + dq);
   case start::december: return from_quarterly(to_quarterly<start::december>(yqn) + dq);
-  default: detail::never_reached();
+  default: throw std::runtime_error("[[unreachable]]");
   }
 }
 
@@ -394,7 +381,7 @@ operator-(const year_quarternum& x, const year_quarternum& y) NOEXCEPT
   case start::october: return to_quarterly<start::october>(x) - to_quarterly<start::october>(y);
   case start::november: return to_quarterly<start::november>(x) - to_quarterly<start::november>(y);
   case start::december: return to_quarterly<start::december>(x) - to_quarterly<start::december>(y);
-  default: detail::never_reached();
+  default: throw std::runtime_error("[[unreachable]]");
   }
 }
 
@@ -459,7 +446,7 @@ year_quarternum_quarterday::from_sys_days(const date::sys_days& dp, quarterly::s
   case start::october: return from_quarterly(quarterly::year_quarternum_quarterday<start::october>(dp));
   case start::november: return from_quarterly(quarterly::year_quarternum_quarterday<start::november>(dp));
   case start::december: return from_quarterly(quarterly::year_quarternum_quarterday<start::december>(dp));
-  default: detail::never_reached();
+  default: throw std::runtime_error("[[unreachable]]");
   }
 }
 
@@ -514,7 +501,7 @@ year_quarternum_quarterday::operator date::sys_days() const NOEXCEPT
   case start::october: return to_quarterly<start::october>(*this);
   case start::november: return to_quarterly<start::november>(*this);
   case start::december: return to_quarterly<start::december>(*this);
-  default: detail::never_reached();
+  default: throw std::runtime_error("[[unreachable]]");
   }
 }
 
@@ -538,7 +525,7 @@ year_quarternum_quarterday::operator date::local_days() const NOEXCEPT
   case start::october: return date::local_days(to_quarterly<start::october>(*this));
   case start::november: return date::local_days(to_quarterly<start::november>(*this));
   case start::december: return date::local_days(to_quarterly<start::december>(*this));
-  default: detail::never_reached();
+  default: throw std::runtime_error("[[unreachable]]");
   }
 }
 
@@ -563,7 +550,7 @@ year_quarternum_quarterday::ok() const NOEXCEPT
   case start::october: return to_quarterly<start::october>(*this).ok();
   case start::november: return to_quarterly<start::november>(*this).ok();
   case start::december: return to_quarterly<start::december>(*this).ok();
-  default: detail::never_reached();
+  default: throw std::runtime_error("[[unreachable]]");
   }
 }
 
@@ -621,7 +608,7 @@ year_quarternum_quarterday_last::quarterday() const NOEXCEPT
   case start::october: return to_quarterly<start::october>(*this).quarterday();
   case start::november: return to_quarterly<start::november>(*this).quarterday();
   case start::december: return to_quarterly<start::december>(*this).quarterday();
-  default: detail::never_reached();
+  default: throw std::runtime_error("[[unreachable]]");
   }
 }
 

--- a/src/week-shim.h
+++ b/src/week-shim.h
@@ -162,19 +162,6 @@ public:
 
 namespace detail {
 
-static
-inline
-void
-never_reached [[noreturn]] () {
-  // Compiler hint to allow [[noreturn]] attribute. This is never executed since
-  // `never_reached()` is never actually called.
-  throw std::runtime_error("[[noreturn]]");
-}
-
-} // namespace detail
-
-namespace detail {
-
 template <week::start S>
 CONSTCD14
 inline
@@ -314,7 +301,7 @@ year::is_leap() const NOEXCEPT {
   case start::thursday: return to_week<start::thursday>(*this).is_leap();
   case start::friday: return to_week<start::friday>(*this).is_leap();
   case start::saturday: return to_week<start::saturday>(*this).is_leap();
-  default: detail::never_reached();
+  default: throw std::runtime_error("[[unreachable]]");
   }
 }
 
@@ -335,7 +322,7 @@ operator+(const year& x, const week::years& y) NOEXCEPT
   case start::thursday: return from_week(to_week<start::thursday>(x) + y);
   case start::friday: return from_week(to_week<start::friday>(x) + y);
   case start::saturday: return from_week(to_week<start::saturday>(x) + y);
-  default: detail::never_reached();
+  default: throw std::runtime_error("[[unreachable]]");
   }
 }
 
@@ -356,7 +343,7 @@ operator-(const year& x, const year& y) NOEXCEPT
   case start::thursday: return to_week<start::thursday>(x) - to_week<start::thursday>(y);
   case start::friday: return to_week<start::friday>(x) - to_week<start::friday>(y);
   case start::saturday: return to_week<start::saturday>(x) - to_week<start::saturday>(y);
-  default: detail::never_reached();
+  default: throw std::runtime_error("[[unreachable]]");
   }
 }
 
@@ -424,7 +411,7 @@ year_weeknum::ok() const NOEXCEPT
   case start::thursday: return to_week<start::thursday>(*this).ok();
   case start::friday: return to_week<start::friday>(*this).ok();
   case start::saturday: return to_week<start::saturday>(*this).ok();
-  default: detail::never_reached();
+  default: throw std::runtime_error("[[unreachable]]");
   }
 }
 
@@ -454,7 +441,7 @@ year_lastweek::weeknum() const NOEXCEPT
   case start::thursday: return to_week<start::thursday>(*this).weeknum();
   case start::friday: return to_week<start::friday>(*this).weeknum();
   case start::saturday: return to_week<start::saturday>(*this).weeknum();
-  default: detail::never_reached();
+  default: throw std::runtime_error("[[unreachable]]");
   }
 }
 
@@ -514,7 +501,7 @@ year_weeknum_weekday::from_sys_days(const date::sys_days& dp, week::start s) NOE
   case start::thursday: return from_week(week::year_weeknum_weekday<start::thursday>(dp));
   case start::friday: return from_week(week::year_weeknum_weekday<start::friday>(dp));
   case start::saturday: return from_week(week::year_weeknum_weekday<start::saturday>(dp));
-  default: detail::never_reached();
+  default: throw std::runtime_error("[[unreachable]]");
   }
 }
 
@@ -564,7 +551,7 @@ year_weeknum_weekday::operator date::sys_days() const NOEXCEPT
   case start::thursday: return to_week<start::thursday>(*this);
   case start::friday: return to_week<start::friday>(*this);
   case start::saturday: return to_week<start::saturday>(*this);
-  default: detail::never_reached();
+  default: throw std::runtime_error("[[unreachable]]");
   }
 }
 
@@ -583,7 +570,7 @@ year_weeknum_weekday::operator date::local_days() const NOEXCEPT
   case start::thursday: return date::local_days(to_week<start::thursday>(*this));
   case start::friday: return date::local_days(to_week<start::friday>(*this));
   case start::saturday: return date::local_days(to_week<start::saturday>(*this));
-  default: detail::never_reached();
+  default: throw std::runtime_error("[[unreachable]]");
   }
 }
 
@@ -603,7 +590,7 @@ year_weeknum_weekday::ok() const NOEXCEPT
   case start::thursday: return to_week<start::thursday>(*this).ok();
   case start::friday: return to_week<start::friday>(*this).ok();
   case start::saturday: return to_week<start::saturday>(*this).ok();
-  default: detail::never_reached();
+  default: throw std::runtime_error("[[unreachable]]");
   }
 }
 
@@ -641,7 +628,7 @@ year_lastweek_weekday::weeknum() const NOEXCEPT
   case start::thursday: return to_week<start::thursday>(*this).weeknum();
   case start::friday: return to_week<start::friday>(*this).weeknum();
   case start::saturday: return to_week<start::saturday>(*this).weeknum();
-  default: detail::never_reached();
+  default: throw std::runtime_error("[[unreachable]]");
   }
 }
 

--- a/src/week-shim.h
+++ b/src/week-shim.h
@@ -301,7 +301,7 @@ year::is_leap() const NOEXCEPT {
   case start::thursday: return to_week<start::thursday>(*this).is_leap();
   case start::friday: return to_week<start::friday>(*this).is_leap();
   case start::saturday: return to_week<start::saturday>(*this).is_leap();
-  default: throw std::runtime_error("[[unreachable]]");
+  default: return /* unreachable */ false;
   }
 }
 
@@ -322,7 +322,7 @@ operator+(const year& x, const week::years& y) NOEXCEPT
   case start::thursday: return from_week(to_week<start::thursday>(x) + y);
   case start::friday: return from_week(to_week<start::friday>(x) + y);
   case start::saturday: return from_week(to_week<start::saturday>(x) + y);
-  default: throw std::runtime_error("[[unreachable]]");
+  default: return /* unreachable */ year();
   }
 }
 
@@ -343,7 +343,7 @@ operator-(const year& x, const year& y) NOEXCEPT
   case start::thursday: return to_week<start::thursday>(x) - to_week<start::thursday>(y);
   case start::friday: return to_week<start::friday>(x) - to_week<start::friday>(y);
   case start::saturday: return to_week<start::saturday>(x) - to_week<start::saturday>(y);
-  default: throw std::runtime_error("[[unreachable]]");
+  default: return /* unreachable */ week::years();
   }
 }
 
@@ -411,7 +411,7 @@ year_weeknum::ok() const NOEXCEPT
   case start::thursday: return to_week<start::thursday>(*this).ok();
   case start::friday: return to_week<start::friday>(*this).ok();
   case start::saturday: return to_week<start::saturday>(*this).ok();
-  default: throw std::runtime_error("[[unreachable]]");
+  default: return /* unreachable */ false;
   }
 }
 
@@ -441,7 +441,7 @@ year_lastweek::weeknum() const NOEXCEPT
   case start::thursday: return to_week<start::thursday>(*this).weeknum();
   case start::friday: return to_week<start::friday>(*this).weeknum();
   case start::saturday: return to_week<start::saturday>(*this).weeknum();
-  default: throw std::runtime_error("[[unreachable]]");
+  default: return /* unreachable */ week::weeknum();
   }
 }
 
@@ -501,7 +501,7 @@ year_weeknum_weekday::from_sys_days(const date::sys_days& dp, week::start s) NOE
   case start::thursday: return from_week(week::year_weeknum_weekday<start::thursday>(dp));
   case start::friday: return from_week(week::year_weeknum_weekday<start::friday>(dp));
   case start::saturday: return from_week(week::year_weeknum_weekday<start::saturday>(dp));
-  default: throw std::runtime_error("[[unreachable]]");
+  default: return /* unreachable */ year_weeknum_weekday();
   }
 }
 
@@ -551,7 +551,7 @@ year_weeknum_weekday::operator date::sys_days() const NOEXCEPT
   case start::thursday: return to_week<start::thursday>(*this);
   case start::friday: return to_week<start::friday>(*this);
   case start::saturday: return to_week<start::saturday>(*this);
-  default: throw std::runtime_error("[[unreachable]]");
+  default: return /* unreachable */ date::sys_days();
   }
 }
 
@@ -570,7 +570,7 @@ year_weeknum_weekday::operator date::local_days() const NOEXCEPT
   case start::thursday: return date::local_days(to_week<start::thursday>(*this));
   case start::friday: return date::local_days(to_week<start::friday>(*this));
   case start::saturday: return date::local_days(to_week<start::saturday>(*this));
-  default: throw std::runtime_error("[[unreachable]]");
+  default: return /* unreachable */ date::local_days();
   }
 }
 
@@ -590,7 +590,7 @@ year_weeknum_weekday::ok() const NOEXCEPT
   case start::thursday: return to_week<start::thursday>(*this).ok();
   case start::friday: return to_week<start::friday>(*this).ok();
   case start::saturday: return to_week<start::saturday>(*this).ok();
-  default: throw std::runtime_error("[[unreachable]]");
+  default: return /* unreachable */ false;
   }
 }
 
@@ -628,7 +628,7 @@ year_lastweek_weekday::weeknum() const NOEXCEPT
   case start::thursday: return to_week<start::thursday>(*this).weeknum();
   case start::friday: return to_week<start::friday>(*this).weeknum();
   case start::saturday: return to_week<start::saturday>(*this).weeknum();
-  default: throw std::runtime_error("[[unreachable]]");
+  default: return /* unreachable */ week::weeknum();
   }
 }
 


### PR DESCRIPTION
Closes https://github.com/r-lib/clock/issues/357

This function was an issue because we used it in `constexpr` contexts

```cpp
static
inline
void
never_reached [[noreturn]] () {
  // Compiler hint to allow [[noreturn]] attribute. This is never executed since
  // `never_reached()` is never actually called.
  throw std::runtime_error("[[noreturn]]");
}
```

We are forced to throw in the unreachable `default` cases of our switch statements due to the fact that you can convert _anything_ to an enum and have it go through the switch statement, even though that doesn't happen in practice.

The `throw` is actually ok in `constexpr` and `noexcept` contexts because it represents an ill-formed function and will completely abort the program (the `noexcept` in particular turns the `throw` into a `terminate()`).

We can't add `constexpr` to this function because it complains that we need to return an expression, but the `[[noreturn]]` is also needed and prevents us from using any `return`s. So my next best solution is to just inline the throw.

Alternatively we could remove the `constexpr` and `noexcept`s but that would really stink to have to do.