### PR TITLE
Fix 'operator"" ' whitespace issue

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # clock (development version)
 
+* Fixed `-Wdeprecated-literal-operator` reported by clang (#386, @MichaelChirico).
+
 # clock 0.7.2
 
 * Added a `diff()` method for time points and calendars to ensure that durations

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # clock (development version)
 
-* Fixed `-Wdeprecated-literal-operator` reported by clang (#386, @MichaelChirico).
+* Fixed `-Wdeprecated-literal-operator` reported by clang (#386,
+  @MichaelChirico).
 
 # clock 0.7.2
 

--- a/src/ordinal.h
+++ b/src/ordinal.h
@@ -237,8 +237,8 @@ operator<<(std::basic_ostream<CharT, Traits>& os, const year_yearday_last& yydl)
 inline namespace literals
 {
 
-CONSTCD11 ordinal::yearday operator "" _yd(unsigned long long yd) NOEXCEPT;
-CONSTCD11 ordinal::year    operator "" _y(unsigned long long y) NOEXCEPT;
+CONSTCD11 ordinal::yearday operator ""_yd(unsigned long long yd) NOEXCEPT;
+CONSTCD11 ordinal::year    operator ""_y(unsigned long long y) NOEXCEPT;
 
 }  // inline namespace literals
 #endif // !defined(_MSC_VER) || (_MSC_VER >= 1900)
@@ -628,7 +628,7 @@ inline namespace literals
 CONSTCD11
 inline
 ordinal::yearday
-operator "" _yd(unsigned long long yd) NOEXCEPT
+operator ""_yd(unsigned long long yd) NOEXCEPT
 {
     return ordinal::yearday{static_cast<unsigned>(yd)};
 }
@@ -636,7 +636,7 @@ operator "" _yd(unsigned long long yd) NOEXCEPT
 CONSTCD11
 inline
 ordinal::year
-operator "" _y(unsigned long long y) NOEXCEPT
+operator ""_y(unsigned long long y) NOEXCEPT
 {
     return ordinal::year(static_cast<int>(y));
 }

--- a/src/week.h
+++ b/src/week.h
@@ -877,7 +877,7 @@ inline namespace literals
 CONSTCD11
 inline
 week::weeknum
-operator "" _w(unsigned long long wn) NOEXCEPT
+operator ""_w(unsigned long long wn) NOEXCEPT
 {
     return week::weeknum(static_cast<unsigned>(wn));
 }


### PR DESCRIPTION
The space after `""` is deprecated since it creates ambiguity with reserved `_`-initial names per:

https://en.cppreference.com/w/cpp/language/user_literal