### PR TITLE
Avoid inverting `not_a_offset`, which is `minutes::min()` i.e. min of `long`

### DIFF
--- a/src/parse.h
+++ b/src/parse.h
@@ -873,7 +873,7 @@ from_stream(std::basic_istream<CharT, Traits>& is,
                             }
                         }
                     }
-                    if (neg)
+                    if (neg && !is.fail())
                         toff = -toff;
                     checked_set(temp_offset, toff, not_a_offset, is);
                     command = nullptr;


### PR DESCRIPTION
With two's complement you can't invert the min value with `-`

Found as part of CRAN's clang20-ubsan checks (note the test failures themselves are unrelated and have been fixed elsewhere), here we are interested in the:

```
negation of -9223372036854775808 cannot be represented in type 'rep' (aka 'long'); cast to an unsigned type to negate this value to itself
```

My guess is that this is the test that triggered it (the `-` parses, so `neg` is set, but `0a:00` doesn't parse, so `toff` is left as `not_a_offset`)

```r
test_that("%z must parse correctly if included", {
  expect <- as_zoned_time(sys_days(NA), "America/New_York")
  x <- "1970-01-01 00:00:00-0a:00 EST"

  expect_warning(
    result <- zoned_time_parse_abbrev(
      x,
      "America/New_York",
      format = "%Y-%m-%d %H:%M:%S%Ez %Z"
    )
  )

  expect_identical(result, expect)
})
```

Full log

```
* using log directory ‘/data/gannet/ripley/R/packages/tests-clang-UBSAN/clock.Rcheck’
* using R Under development (unstable) (2025-03-16 r87984)
* using platform: x86_64-pc-linux-gnu
* R was compiled by
    clang version 20.1.0
    flang version 20.1.0
* running under: Fedora Linux 40 (Workstation Edition)
* using session charset: UTF-8
* using option ‘--no-stop-on-test-error’
* checking for file ‘clock/DESCRIPTION’ ... OK
* this is package ‘clock’ version ‘0.7.2’
* package encoding: UTF-8
* checking package dependencies ... OK
* checking if this is a source package ... OK
* checking if there is a namespace ... OK
* checking for hidden files and directories ... OK
* checking for portable file names ... OK
* checking whether package ‘clock’ can be installed ... [419s/322s] WARNING
Found the following significant warnings:
  ./ordinal.h:240:40: warning: identifier '_yd' preceded by whitespace in a literal operator declaration is deprecated [-Wdeprecated-literal-operator]
  ./ordinal.h:241:40: warning: identifier '_y' preceded by whitespace in a literal operator declaration is deprecated [-Wdeprecated-literal-operator]
  ./ordinal.h:631:13: warning: identifier '_yd' preceded by whitespace in a literal operator declaration is deprecated [-Wdeprecated-literal-operator]
  ./ordinal.h:639:13: warning: identifier '_y' preceded by whitespace in a literal operator declaration is deprecated [-Wdeprecated-literal-operator]
  ./week.h:880:13: warning: identifier '_w' preceded by whitespace in a literal operator declaration is deprecated [-Wdeprecated-literal-operator]
See ‘/data/gannet/ripley/R/packages/tests-clang-UBSAN/clock.Rcheck/00install.out’ for details.
* used C++ compiler: ‘clang version 20.1.0’
* checking package directory ... OK
* checking whether the package can be loaded ... OK
* checking whether the package can be loaded with stated dependencies ... OK
* checking whether the package can be unloaded cleanly ... OK
* checking whether the namespace can be loaded with stated dependencies ... OK
* checking whether the namespace can be unloaded cleanly ... OK
* checking loading without being on the library search path ... OK
* checking compiled code ... OK
* checking installed files from ‘inst/doc’ ... OK
* checking files in ‘vignettes’ ... OK
* checking examples ... OK
* checking tests ... [168s/189s] ERROR
  Running ‘testthat.R’ [167s/188s]
Running the tests in ‘tests/testthat.R’ failed.
Complete output:
  > library(testthat)
  > library(clock)
  > 
  > test_check("clock")
  /usr/local/clang20/bin/../include/c++/v1/__chrono/duration.h:231:49: runtime error: negation of -9223372036854775808 cannot be represented in type 'rep' (aka 'long'); cast to an unsigned type to negate this value to itself
      #0 0x7fb910a154cb in std::__1::chrono::duration<long, std::__1::ratio<60l, 1l>>::operator-[abi:ne200100]() const /usr/local/clang20/bin/../include/c++/v1/__chrono/duration.h:231:49
      #1 0x7fb910a154cb in std::__1::basic_istream<char, std::__1::char_traits<char>>& rclock::from_stream<char, std::__1::char_traits<char>, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1l>>, std::__1::allocator<char>>(std::__1::basic_istream<char, std::__1::char_traits<char>>&, char const*, std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const*> const&, std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const*> const&, std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const*> const&, char const&, date::fields<std::__1::chrono::duration<long long, std::__1::ratio<1l, 1l>>>&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>*, std::__1::chrono::duration<long, std::__1::ratio<60l, 1l>>*) /data/gannet/ripley/R/packages/tests-clang-UBSAN/clock/src/./parse.h:870:32
      #2 0x7fb910a987f1 in std::__1::basic_istream<char, std::__1::char_traits<char>>& rclock::from_stream<std::__1::chrono::duration<int, std::__1::ratio<86400l, 1l>>, char, std::__1::char_traits<char>, std::__1::allocator<char>>(std::__1::basic_istream<char, std::__1::char_traits<char>>&, char const*, std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const*> const&, std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const*> const&, std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const*> const&, char const&, std::__1::chrono::time_point<date::local_t, std::__1::chrono::duration<int, std::__1::ratio<86400l, 1l>>>&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>*, std::__1::chrono::duration<long, std::__1::ratio<60l, 1l>>*) /data/gannet/ripley/R/packages/tests-clang-UBSAN/clock/src/./parse.h:1250:3
      #3 0x7fb910a92bc2 in void time_point_parse_one<rclock::duration::duration<std::__1::chrono::duration<int, std::__1::ratio<86400l, 1l>>>, date::local_t>(std::__1::basic_istringstream<char, std::__1::char_traits<char>, std::__1::allocator<char>>&, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>> const&, std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const*> const&, std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const*> const&, std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const*> const&, char const&, long const&, rclock::failures&, rclock::duration::duration<std::__1::chrono::duration<int, std::__1::ratio<86400l, 1l>>>&) /data/gannet/ripley/R/packages/tests-clang-UBSAN/clock/src/time-point.cpp:113:5
      #4 0x7fb910a92bc2 in cpp11::writable::r_vector<SEXPREC*> time_point_parse_impl<rclock::duration::duration<std::__1::chrono::duration<int, std::__1::ratio<86400l, 1l>>>, date::local_t>(cpp11::r_vector<cpp11::r_string> const&, cpp11::r_vector<cpp11::r_string> const&, cpp11::r_vector<cpp11::r_string> const&, cpp11::r_vector<cpp11::r_string> const&, cpp11::r_vector<cpp11::r_string> const&, cpp11::r_vector<cpp11::r_string> const&, cpp11::r_vector<cpp11::r_string> const&, cpp11::r_vector<cpp11::r_string> const&) /data/gannet/ripley/R/packages/tests-clang-UBSAN/clock/src/time-point.cpp:195:5
      #5 0x7fb910a92bc2 in time_point_parse_cpp(cpp11::r_vector<cpp11::r_string> const&, cpp11::r_vector<cpp11::r_string> const&, cpp11::r_vector<int> const&, cpp11::r_vector<int> const&, cpp11::r_vector<cpp11::r_string> const&, cpp11::r_vector<cpp11::r_string> const&, cpp11::r_vector<cpp11::r_string> const&, cpp11::r_vector<cpp11::r_string> const&, cpp11::r_vector<cpp11::r_string> const&, cpp11::r_vector<cpp11::r_string> const&) /data/gannet/ripley/R/packages/tests-clang-UBSAN/clock/src/time-point.cpp:234:33
      #6 0x7fb91091bb9f in _clock_time_point_parse_cpp /data/gannet/ripley/R/packages/tests-clang-UBSAN/clock/src/cpp11.cpp:768:27
      #7 0x5631dd05c66b in R_doDotCall (/data/gannet/ripley/R/R-clang/bin/exec/R+0xf366b)
      #8 0x5631dd099ee0 in bcEval_loop eval.c
      #9 0x5631dd09279b in bcEval eval.c
      #10 0x5631dd091f24 in Rf_eval (/data/gannet/ripley/R/R-clang/bin/exec/R+0x128f24)
      #11 0x5631dd0aa71f in R_execClosure eval.c
      #12 0x5631dd0a9c0b in applyClosure_core eval.c
      #13 0x5631dd092375 in Rf_eval (/data/gannet/ripley/R/R-clang/bin/exec/R+0x129375)
      #14 0x5631dd05931b in do_External (/data/gannet/ripley/R/R-clang/bin/exec/R+0xf031b)
      #15 0x5631dd098e06 in bcEval_loop eval.c
      #16 0x5631dd09279b in bcEval eval.c
      #17 0x5631dd091f24 in Rf_eval (/data/gannet/ripley/R/R-clang/bin/exec/R+0x128f24)
      #18 0x5631dd0aa71f in R_execClosure eval.c
      #19 0x5631dd0a9c0b in applyClosure_core eval.c
      #20 0x5631dd092375 in Rf_eval (/data/gannet/ripley/R/R-clang/bin/exec/R+0x129375)
      #21 0x5631dd0aee7a in do_begin (/data/gannet/ripley/R/R-clang/bin/exec/R+0x145e7a)
      #22 0x5631dd09214f in Rf_eval (/data/gannet/ripley/R/R-clang/bin/exec/R+0x12914f)
      #23 0x5631dd0b10ab in do_eval (/data/gannet/ripley/R/R-clang/bin/exec/R+0x1480ab)
      #24 0x5631dd098e06 in bcEval_loop eval.c
      #25 0x5631dd09279b in bcEval eval.c
      #26 0x5631dd091f24 in Rf_eval (/data/gannet/ripley/R/R-clang/bin/exec/R+0x128f24)
      #27 0x5631dd0aa71f in R_execClosure eval.c
      #28 0x5631dd0a9c0b in applyClosure_core eval.c
      #29 0x5631dd092375 in Rf_eval (/data/gannet/ripley/R/R-clang/bin/exec/R+0x129375)
      #30 0x5631dd0b1487 in do_eval (/data/gannet/ripley/R/R-clang/bin/exec/R+0x148487)
      #31 0x5631dd098e06 in bcEval_loop eval.c
      #32 0x5631dd09279b in bcEval eval.c
      #33 0x5631dd091f24 in Rf_eval (/data/gannet/ripley/R/R-clang/bin/exec/R+0x128f24)
      #34 0x5631dd0aa71f in R_execClosure eval.c
      #35 0x5631dd0a9c0b in applyClosure_core eval.c
      #36 0x5631dd0ad194 in R_forceAndCall (/data/gannet/ripley/R/R-clang/bin/exec/R+0x144194)
      #37 0x5631dcfe36cb in do_lapply (/data/gannet/ripley/R/R-clang/bin/exec/R+0x7a6cb)
      #38 0x5631dd0f4187 in do_internal (/data/gannet/ripley/R/R-clang/bin/exec/R+0x18b187)
      #39 0x5631dd09ba7a in bcEval_loop eval.c
      #40 0x5631dd09279b in bcEval eval.c
      #41 0x5631dd091f24 in Rf_eval (/data/gannet/ripley/R/R-clang/bin/exec/R+0x128f24)
      #42 0x5631dd0aa71f in R_execClosure eval.c
      #43 0x5631dd0a9c0b in applyClosure_core eval.c
      #44 0x5631dd092375 in Rf_eval (/data/gannet/ripley/R/R-clang/bin/exec/R+0x129375)
      #45 0x5631dd0df5d0 in Rf_ReplIteration (/data/gannet/ripley/R/R-clang/bin/exec/R+0x1765d0)
      #46 0x5631dd0e0f4e in run_Rmainloop (/data/gannet/ripley/R/R-clang/bin/exec/R+0x177f4e)
      #47 0x5631dd0e0fba in Rf_mainloop (/data/gannet/ripley/R/R-clang/bin/exec/R+0x177fba)
      #48 0x5631dcfd0a47 in main (/data/gannet/ripley/R/R-clang/bin/exec/R+0x67a47)
      #49 0x7fb92173c087 in __libc_start_call_main (/lib64/libc.so.6+0x2a087) (BuildId: c8c3fa52aaee3f5d73b6fd862e39e9d4c010b6ba)
      #50 0x7fb92173c14a in __libc_start_main@GLIBC_2.2.5 (/lib64/libc.so.6+0x2a14a) (BuildId: c8c3fa52aaee3f5d73b6fd862e39e9d4c010b6ba)
      #51 0x5631dcfd0964 in _start (/data/gannet/ripley/R/R-clang/bin/exec/R+0x67964)
  
  SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /usr/local/clang20/bin/../include/c++/v1/__chrono/duration.h:231:49 
  [ FAIL 33 | WARN 29 | SKIP 360 | PASS 1860 ]
  
  ══ Skipped tests (360) ═════════════════════════════════════════════════════════
  • Not on Mac (4): 'test-duration.R:624:3', 'test-duration.R:642:3',
    'test-time-point.R:530:3', 'test-time-point.R:568:3'
  • On CRAN (356): 'test-arithmetic.R:7:3', 'test-calendar.R:6:3',
    'test-calendar.R:12:3', 'test-calendar.R:25:3', 'test-calendar.R:33:3',
    'test-calendar.R:43:3', 'test-calendar.R:47:3', 'test-calendar.R:51:3',
    'test-calendar.R:56:3', 'test-calendar.R:68:3', 'test-calendar.R:72:3',
    'test-calendar.R:76:3', 'test-calendar.R:81:3', 'test-calendar.R:93:3',
    'test-calendar.R:97:3', 'test-calendar.R:101:3', 'test-calendar.R:106:3',
    'test-calendar.R:118:3', 'test-calendar.R:122:3', 'test-calendar.R:127:3',
    'test-calendar.R:131:3', 'test-calendar.R:136:3', 'test-calendar.R:190:3',
    'test-calendar.R:194:3', 'test-calendar.R:199:3', 'test-calendar.R:203:3',
    'test-calendar.R:208:3', 'test-calendar.R:306:3', 'test-calendar.R:311:3',
    'test-calendar.R:317:3', 'test-calendar.R:351:3', 'test-calendar.R:357:3',
    'test-calendar.R:369:3', 'test-calendar.R:389:3', 'test-calendar.R:398:3',
    'test-clock-deprecated.R:7:3', 'test-clock-deprecated.R:17:3',
    'test-clock-deprecated.R:29:3', 'test-clock-deprecated.R:39:3',
    'test-clock-labels.R:12:3', 'test-clock-labels.R:20:3',
    'test-clock-labels.R:53:3', 'test-clock-labels.R:57:3',
    'test-clock-labels.R:68:3', 'test-clock-locale.R:4:3',
    'test-clock-locale.R:14:3', 'test-clock-locale.R:18:3',
    'test-clock-locale.R:24:3', 'test-date.R:49:3', 'test-date.R:107:3',
    'test-date.R:122:3', 'test-date.R:174:3', 'test-date.R:180:3',
    'test-date.R:203:3', 'test-date.R:216:3', 'test-date.R:283:3',
    'test-date.R:305:3', 'test-date.R:348:3', 'test-date.R:384:3',
    'test-date.R:412:3', 'test-date.R:426:3', 'test-date.R:483:3',
    'test-date.R:529:3', 'test-date.R:548:3', 'test-date.R:552:3',
    'test-date.R:558:3', 'test-date.R:562:3', 'test-date.R:568:3',
    'test-date.R:572:3', 'test-date.R:579:3', 'test-date.R:643:3',
    'test-date.R:649:3', 'test-date.R:659:3', 'test-date.R:666:3',
    'test-date.R:738:3', 'test-duration.R:104:3', 'test-duration.R:109:3',
    'test-duration.R:124:3', 'test-duration.R:129:3', 'test-duration.R:134:3',
    'test-duration.R:140:3', 'test-duration.R:147:3', 'test-duration.R:160:3',
    'test-duration.R:183:3', 'test-duration.R:198:3', 'test-duration.R:217:3',
    'test-duration.R:221:3', 'test-duration.R:385:3', 'test-duration.R:422:3',
    'test-duration.R:431:3', 'test-duration.R:444:3', 'test-duration.R:474:3',
    'test-duration.R:481:3', 'test-duration.R:508:3', 'test-duration.R:560:3',
    'test-duration.R:700:3', 'test-getters.R:7:3',
    'test-gregorian-year-day.R:25:3', 'test-gregorian-year-day.R:116:3',
    'test-gregorian-year-day.R:128:3', 'test-gregorian-year-day.R:182:3',
    'test-gregorian-year-day.R:192:3', 'test-gregorian-year-day.R:221:3',
    'test-gregorian-year-day.R:248:3', 'test-gregorian-year-day.R:269:3',
    'test-gregorian-year-day.R:373:3', 'test-gregorian-year-day.R:380:3',
    'test-gregorian-year-day.R:387:3', 'test-gregorian-year-day.R:394:3',
    'test-gregorian-year-day.R:569:3', 'test-gregorian-year-day.R:598:3',
    'test-gregorian-year-day.R:709:3', 'test-gregorian-year-day.R:746:3',
    'test-gregorian-year-day.R:797:3', 'test-gregorian-year-day.R:812:3',
    'test-gregorian-year-day.R:825:3', 'test-gregorian-year-day.R:897:3',
    'test-gregorian-year-month-day.R:25:3',
    'test-gregorian-year-month-day.R:31:3',
    'test-gregorian-year-month-day.R:37:3',
    'test-gregorian-year-month-day.R:135:3',
    'test-gregorian-year-month-day.R:149:3',
    'test-gregorian-year-month-day.R:171:3',
    'test-gregorian-year-month-day.R:231:3',
    'test-gregorian-year-month-day.R:241:3',
    'test-gregorian-year-month-day.R:273:3',
    'test-gregorian-year-month-day.R:303:3',
    'test-gregorian-year-month-day.R:336:3',
    'test-gregorian-year-month-day.R:446:3',
    'test-gregorian-year-month-day.R:453:3',
    'test-gregorian-year-month-day.R:460:3',
    'test-gregorian-year-month-day.R:467:3',
    'test-gregorian-year-month-day.R:604:3',
    'test-gregorian-year-month-day.R:898:3',
    'test-gregorian-year-month-day.R:902:3',
    'test-gregorian-year-month-day.R:909:3',
    'test-gregorian-year-month-day.R:955:3',
    'test-gregorian-year-month-day.R:990:3',
    'test-gregorian-year-month-day.R:1116:3',
    'test-gregorian-year-month-day.R:1153:3',
    'test-gregorian-year-month-day.R:1215:3',
    'test-gregorian-year-month-day.R:1230:3',
    'test-gregorian-year-month-day.R:1244:3',
    'test-gregorian-year-month-day.R:1343:3',
    'test-gregorian-year-month-weekday.R:46:3',
    'test-gregorian-year-month-weekday.R:50:3',
    'test-gregorian-year-month-weekday.R:180:3',
    'test-gregorian-year-month-weekday.R:188:3',
    'test-gregorian-year-month-weekday.R:202:3',
    'test-gregorian-year-month-weekday.R:265:3',
    'test-gregorian-year-month-weekday.R:275:3',
    'test-gregorian-year-month-weekday.R:310:3',
    'test-gregorian-year-month-weekday.R:343:3',
    'test-gregorian-year-month-weekday.R:376:3',
    'test-gregorian-year-month-weekday.R:492:3',
    'test-gregorian-year-month-weekday.R:572:3',
    'test-gregorian-year-month-weekday.R:599:3',
    'test-gregorian-year-month-weekday.R:676:3',
    'test-gregorian-year-month-weekday.R:683:3',
    'test-gregorian-year-month-weekday.R:753:3',
    'test-gregorian-year-month-weekday.R:870:3',
    'test-gregorian-year-month-weekday.R:924:3',
    'test-gregorian-year-month-weekday.R:939:3',
    'test-gregorian-year-month-weekday.R:951:3',
    'test-gregorian-year-month-weekday.R:1002:3',
    'test-gregorian-year-month-weekday.R:1062:3', 'test-invalid.R:13:3',
    'test-iso-year-week-day.R:25:3', 'test-iso-year-week-day.R:120:3',
    'test-iso-year-week-day.R:134:3', 'test-iso-year-week-day.R:193:3',
    'test-iso-year-week-day.R:203:3', 'test-iso-year-week-day.R:235:3',
    'test-iso-year-week-day.R:265:3', 'test-iso-year-week-day.R:298:3',
    'test-iso-year-week-day.R:408:3', 'test-iso-year-week-day.R:581:3',
    'test-iso-year-week-day.R:610:3', 'test-iso-year-week-day.R:708:3',
    'test-iso-year-week-day.R:745:3', 'test-iso-year-week-day.R:799:3',
    'test-iso-year-week-day.R:814:3', 'test-iso-year-week-day.R:828:3',
    'test-iso-year-week-day.R:901:3', 'test-naive-time.R:92:3',
    'test-naive-time.R:99:3', 'test-naive-time.R:193:3',
    'test-naive-time.R:219:3', 'test-naive-time.R:351:3',
    'test-naive-time.R:360:3', 'test-naive-time.R:368:3',
    'test-naive-time.R:377:3', 'test-naive-time.R:423:3',
    'test-naive-time.R:461:3', 'test-naive-time.R:501:3',
    'test-naive-time.R:575:3', 'test-naive-time.R:609:3',
    'test-naive-time.R:625:3', 'test-naive-time.R:636:3',
    'test-naive-time.R:648:3', 'test-naive-time.R:668:3',
    'test-naive-time.R:675:3', 'test-naive-time.R:682:3', 'test-posixt.R:26:3',
    'test-posixt.R:84:3', 'test-posixt.R:99:3', 'test-posixt.R:201:3',
    'test-posixt.R:207:3', 'test-posixt.R:212:3', 'test-posixt.R:241:3',
    'test-posixt.R:263:3', 'test-posixt.R:273:3', 'test-posixt.R:352:3',
    'test-posixt.R:359:3', 'test-posixt.R:388:3', 'test-posixt.R:392:3',
    'test-posixt.R:409:3', 'test-posixt.R:413:3', 'test-posixt.R:427:3',
    'test-posixt.R:461:3', 'test-posixt.R:490:3', 'test-posixt.R:519:3',
    'test-posixt.R:581:3', 'test-posixt.R:602:3', 'test-posixt.R:608:3',
    'test-posixt.R:619:3', 'test-posixt.R:630:3', 'test-posixt.R:686:3',
    'test-posixt.R:704:3', 'test-posixt.R:721:3', 'test-posixt.R:732:3',
    'test-posixt.R:747:3', 'test-posixt.R:797:3', 'test-posixt.R:882:3',
    'test-posixt.R:894:3', 'test-posixt.R:906:3', 'test-posixt.R:923:3',
    'test-posixt.R:967:3', 'test-posixt.R:1057:3', 'test-posixt.R:1125:3',
    'test-posixt.R:1136:3', 'test-posixt.R:1140:3', 'test-posixt.R:1146:3',
    'test-posixt.R:1153:3', 'test-posixt.R:1159:3', 'test-posixt.R:1163:3',
    'test-posixt.R:1170:3', 'test-posixt.R:1361:3', 'test-posixt.R:1367:3',
    'test-posixt.R:1407:3', 'test-posixt.R:1448:3', 'test-posixt.R:1620:3',
    'test-posixt.R:1636:3', 'test-posixt.R:1652:3', 'test-posixt.R:1668:3',
    'test-quarterly-year-quarter-day.R:25:3',
    'test-quarterly-year-quarter-day.R:120:3',
    'test-quarterly-year-quarter-day.R:135:3',
    'test-quarterly-year-quarter-day.R:195:3',
    'test-quarterly-year-quarter-day.R:205:3',
    'test-quarterly-year-quarter-day.R:237:3',
    'test-quarterly-year-quarter-day.R:267:3',
    'test-quarterly-year-quarter-day.R:300:3',
    'test-quarterly-year-quarter-day.R:410:3',
    'test-quarterly-year-quarter-day.R:587:3',
    'test-quarterly-year-quarter-day.R:622:3',
    'test-quarterly-year-quarter-day.R:786:3',
    'test-quarterly-year-quarter-day.R:823:3',
    'test-quarterly-year-quarter-day.R:857:3',
    'test-quarterly-year-quarter-day.R:877:3',
    'test-quarterly-year-quarter-day.R:897:3',
    'test-quarterly-year-quarter-day.R:976:3',
    'test-quarterly-year-quarter-day.R:1028:3', 'test-sys-time.R:124:3',
    'test-sys-time.R:184:3', 'test-sys-time.R:189:3', 'test-sys-time.R:195:3',
    'test-sys-time.R:201:3', 'test-sys-time.R:208:3', 'test-sys-time.R:222:3',
    'test-sys-time.R:229:3', 'test-sys-time.R:236:3', 'test-time-point.R:6:3',
    'test-time-point.R:12:3', 'test-time-point.R:25:3', 'test-time-point.R:68:3',
    'test-time-point.R:74:3', 'test-time-point.R:87:3', 'test-time-point.R:93:3',
    'test-time-point.R:99:3', 'test-time-point.R:106:3',
    'test-time-point.R:171:3', 'test-time-point.R:175:3',
    'test-time-point.R:179:3', 'test-time-point.R:183:3',
    'test-time-point.R:192:3', 'test-time-point.R:257:3',
    'test-time-point.R:264:3', 'test-time-point.R:274:3',
    'test-time-point.R:286:3', 'test-time-point.R:298:3',
    'test-time-point.R:400:3', 'test-time-point.R:407:3',
    'test-time-point.R:416:3', 'test-time-point.R:449:3',
    'test-time-point.R:458:3', 'test-time-point.R:473:3',
    'test-time-point.R:482:3', 'test-utils.R:10:3',
    'test-week-year-week-day.R:25:3', 'test-week-year-week-day.R:114:3',
    'test-week-year-week-day.R:129:3', 'test-week-year-week-day.R:189:3',
    'test-week-year-week-day.R:199:3', 'test-week-year-week-day.R:231:3',
    'test-week-year-week-day.R:261:3', 'test-week-year-week-day.R:285:3',
    'test-week-year-week-day.R:395:3', 'test-week-year-week-day.R:518:3',
    'test-week-year-week-day.R:547:3', 'test-week-year-week-day.R:740:3',
    'test-week-year-week-day.R:777:3', 'test-week-year-week-day.R:811:3',
    'test-week-year-week-day.R:831:3', 'test-week-year-week-day.R:851:3',
    'test-week-year-week-day.R:917:3', 'test-week-year-week-day.R:969:3',
    'test-weekday.R:5:3', 'test-weekday.R:9:3', 'test-weekday.R:13:3',
    'test-weekday.R:17:3', 'test-weekday.R:21:3', 'test-weekday.R:58:3',
    'test-weekday.R:62:3', 'test-weekday.R:115:3', 'test-weekday.R:119:3',
    'test-weekday.R:123:3', 'test-weekday.R:128:3', 'test-weekday.R:168:3',
    'test-zoned-time.R:10:3', 'test-zoned-time.R:25:3', 'test-zoned-time.R:31:3',
    'test-zoned-time.R:44:3', 'test-zoned-time.R:53:3', 'test-zoned-time.R:64:3',
    'test-zoned-time.R:171:3', 'test-zoned-time.R:205:3',
    'test-zoned-time.R:224:3', 'test-zoned-time.R:456:3',
    'test-zoned-time.R:462:3', 'test-zoned-time.R:591:3',
    'test-zoned-time.R:600:3', 'test-zoned-time.R:611:3',
    'test-zoned-time.R:680:3', 'test-zoned-time.R:700:3',
    'test-zoned-time.R:721:3'
  
  ══ Failed tests ════════════════════════════════════════════════════════════════
  ── Failure ('test-date.R:315:3'): `%z` and `%Z` commands are ignored ───────────
  date_parse("2019-12-31 -0500", format = "%Y-%m-%d %z") (`actual`) not identical to as.Date("2019-12-31") (`expected`).
  
  `actual`:   NA          
  `expected`: "2019-12-31"
  ── Failure ('test-naive-time.R:272:3'): %z is completely ignored, but is required to be parsed correctly if specified ──
  naive_time_parse(x, format = "%Y-%m-%d %H:%M:%S%z") (`actual`) not identical to as_naive_time(year_month_day(2019, 1, 1, 0, 0, 0)) (`expected`).
  
    `actual$lower`:           NA
  `expected$lower`: 2147483648.0
  
    `actual$upper`:           NA
  `expected$upper`: 1546300800.0
  ── Failure ('test-posixt.R:468:3'): can parse into a POSIXct ───────────────────
  date_time_parse_complete("2019-12-31T23:59:59-05:00[America/New_York]") (`actual`) not identical to as.POSIXct("2019-12-31 23:59:59", tz = "America/New_York") (`expected`).
  
  `attr(actual, 'tzone')`:   "UTC"             
  `attr(expected, 'tzone')`: "America/New_York"
  
  `actual`:   NA                   
  `expected`: "2019-12-31 23:59:59"
  ── Failure ('test-posixt.R:475:3'): ambiguity is resolved through the string ───
  date_time_parse_complete("1970-10-25T01:30:00-04:00[America/New_York]") (`actual`) not identical to add_seconds(...) (`expected`).
  
  `attr(actual, 'tzone')`:   "UTC"             
  `attr(expected, 'tzone')`: "America/New_York"
  
  `actual`:   NA                   
  `expected`: "1970-10-25 01:30:00"
  ── Failure ('test-posixt.R:479:3'): ambiguity is resolved through the string ───
  date_time_parse_complete("1970-10-25T01:30:00-05:00[America/New_York]") (`actual`) not identical to add_seconds(...) (`expected`).
  
  `attr(actual, 'tzone')`:   "UTC"             
  `attr(expected, 'tzone')`: "America/New_York"
  
  `actual`:   NA                   
  `expected`: "1970-10-25 01:30:00"
  ── Failure ('test-posixt.R:767:3'): can automatically resolve ambiguous issues ──
  date_start(x, "day") (`actual`) not identical to date_time_parse_complete("2021-10-29T00:00:00+03:00[Asia/Amman]") (`expected`).
  
  `attr(actual, 'tzone')`:   "Asia/Amman"
  `attr(expected, 'tzone')`: "UTC"       
  
  `actual`:   "2021-10-29"
  `expected`: NA          
  ── Failure ('test-posixt.R:774:3'): can automatically resolve ambiguous issues ──
  date_start(x, "day") (`actual`) not identical to date_time_parse_complete("2021-10-29T00:00:00+02:00[Asia/Amman]") (`expected`).
  
  `attr(actual, 'tzone')`:   "Asia/Amman"
  `attr(expected, 'tzone')`: "UTC"       
  
  `actual`:   "2021-10-29"
  `expected`: NA          
  ── Failure ('test-sys-time.R:112:3'): %z shifts the result by the offset ───────
  sys_time_parse(x, format = "%Y-%m-%dT%H:%M:%S%z") (`actual`) not identical to as_sys_time(year_month_day(2018, 12, 31, 23, 0, 0)) (`expected`).
  
    `actual$lower`:           NA
  `expected$lower`: 2147483648.0
  
    `actual$upper`:           NA
  `expected$upper`: 1546297200.0
  ── Failure ('test-sys-time.R:116:3'): %z shifts the result by the offset ───────
  sys_time_parse(y, format = "%Y-%m-%dT%H:%M:%S%z") (`actual`) not identical to as_sys_time(year_month_day(2019, 1, 1, 1, 0, 0)) (`expected`).
  
    `actual$lower`:           NA
  `expected$lower`: 2147483648.0
  
    `actual$upper`:           NA
  `expected$upper`: 1546304400.0
  ── Failure ('test-sys-time.R:170:3'): can parse with alternative offset ────────
  sys_time_parse_RFC_3339(x, offset = "%z") (`actual`) not identical to as_sys_time(year_month_day(2019, 1, 1, 1, 30, 0)) (`expected`).
  
    `actual$lower`:           NA
  `expected$lower`: 2147483648.0
  
    `actual$upper`:           NA
  `expected$upper`: 1546306200.0
  ── Failure ('test-sys-time.R:176:3'): can parse with alternative offset ────────
  sys_time_parse_RFC_3339(x, offset = "%Ez") (`actual`) not identical to as_sys_time(year_month_day(2019, 1, 1, 1, 30, 0)) (`expected`).
  
    `actual$upper`: 1546300800.0
  `expected$upper`: 1546306200.0
  ── Failure ('test-zoned-time.R:75:3'): as.character() works ────────────────────
  as.character(x) (`actual`) not identical to `expect` (`expected`).
  
  `actual`:   NA                                           
  `expected`: "2019-01-01T01:02:03-05:00[America/New_York]"
  ── Failure ('test-zoned-time.R:86:3'): can parse what we format with seconds precision zoned time ──
  zoned_time_parse_complete(format(x)) (`actual`) not identical to `x` (`expected`).
  
  `attr(actual, 'zone')`:   "UTC"             
  `attr(expected, 'zone')`: "America/New_York"
  
    `actual$lower`:           NA
  `expected$lower`: 2147483648.0
  
    `actual$upper`:           NA
  `expected$upper`: 1546318800.0
  ── Failure ('test-zoned-time.R:99:3'): can parse subsecond zoned time ──────────
  zoned_time_parse_complete(x, precision = "millisecond") (`actual`) not identical to as_zoned_time(...) (`expected`).
  
  `attr(actual, 'zone')`:   "UTC"             
  `attr(expected, 'zone')`: "America/New_York"
  
    `actual$lower`:           NA
  `expected$lower`: 2147484008.0
  
    `actual$upper`:          NA
  `expected$upper`: 134296563.0
  ── Failure ('test-zoned-time.R:108:3'): can parse subsecond zoned time ─────────
  zoned_time_parse_complete(y, precision = "microsecond") (`actual`) not identical to as_zoned_time(...) (`expected`).
  
  `attr(actual, 'zone')`:   "UTC"             
  `attr(expected, 'zone')`: "America/New_York"
  
    `actual$lower`:           NA
  `expected$lower`: 2147843679.0
  
    `actual$upper`:           NA
  `expected$upper`: 1152577224.0
  ── Failure ('test-zoned-time.R:117:3'): can parse subsecond zoned time ─────────
  zoned_time_parse_complete(z, precision = "nanosecond") (`actual`) not identical to as_zoned_time(...) (`expected`).
  
  `attr(actual, 'zone')`:   "UTC"             
  `attr(expected, 'zone')`: "America/New_York"
  
    `actual$lower`:           NA
  `expected$lower`: 2507514916.0
  
    `actual$upper`:           NA
  `expected$upper`: 1526045461.0
  ── Failure ('test-zoned-time.R:150:3'): multiple formats can be used ───────────
  zoned_time_parse_complete(x, format = formats) (`actual`) not identical to as_zoned_time(...) (`expected`).
  
  `attr(actual, 'zone')`:   "UTC"             
  `attr(expected, 'zone')`: "America/New_York"
  
    `actual$lower`:           NA           NA
  `expected$lower`: 2147483648.0 2147483648.0
  
    `actual$upper`:         NA         NA
  `expected$upper`: 25698600.0 25698600.0
  ── Failure ('test-zoned-time.R:164:3'): cannot parse nonexistent time ──────────
  zoned_time_parse_complete(x) (`actual`) not identical to as_zoned_time(naive_seconds(NA), zone) (`expected`).
  
  `attr(actual, 'zone')`:   "UTC"             
  `attr(expected, 'zone')`: "America/New_York"
  Backtrace:
      ▆
   1. ├─testthat::expect_warning(...) at test-zoned-time.R:164:3
   2. │ └─testthat:::expect_condition_matching(...)
   3. │   └─testthat:::quasi_capture(...)
   4. │     ├─testthat (local) .capture(...)
   5. │     │ └─base::withCallingHandlers(...)
   6. │     └─rlang::eval_bare(quo_get_expr(.quo), quo_get_env(.quo))
   7. └─testthat::expect_identical(...)
  ── Failure ('test-zoned-time.R:182:3'): ambiguous times are resolved by the offset ──
  zoned_time_parse_complete(x) (`actual`) not identical to as_zoned_time(...) (`expected`).
  
  `attr(actual, 'zone')`:   "UTC"             
  `attr(expected, 'zone')`: "America/New_York"
  
    `actual$lower`:           NA           NA
  `expected$lower`: 2147483648.0 2147483648.0
  
    `actual$upper`:         NA         NA
  `expected$upper`: 25680600.0 25684200.0
  ── Failure ('test-zoned-time.R:198:3'): offset must align with unique offset ───
  zoned_time_parse_complete(x) (`actual`) not identical to as_zoned_time(naive_seconds(NA), zone) (`expected`).
  
  `attr(actual, 'zone')`:   "UTC"             
  `attr(expected, 'zone')`: "America/New_York"
  Backtrace:
      ▆
   1. ├─testthat::expect_warning(...) at test-zoned-time.R:198:3
   2. │ └─testthat:::expect_condition_matching(...)
   3. │   └─testthat:::quasi_capture(...)
   4. │     ├─testthat (local) .capture(...)
   5. │     │ └─base::withCallingHandlers(...)
   6. │     └─rlang::eval_bare(quo_get_expr(.quo), quo_get_env(.quo))
   7. └─testthat::expect_identical(...)
  ── Failure ('test-zoned-time.R:217:3'): offset must align with one of two possible ambiguous offsets ──
  zoned_time_parse_complete(x) (`actual`) not identical to as_zoned_time(naive_seconds(c(NA, NA)), zone) (`expected`).
  
  `attr(actual, 'zone')`:   "UTC"             
  `attr(expected, 'zone')`: "America/New_York"
  Backtrace:
      ▆
   1. ├─testthat::expect_warning(...) at test-zoned-time.R:217:3
   2. │ └─testthat:::expect_condition_matching(...)
   3. │   └─testthat:::quasi_capture(...)
   4. │     ├─testthat (local) .capture(...)
   5. │     │ └─base::withCallingHandlers(...)
   6. │     └─rlang::eval_bare(quo_get_expr(.quo), quo_get_env(.quo))
   7. └─testthat::expect_identical(...)
  ── Failure ('test-zoned-time.R:233:3'): cannot have differing zone names ───────
  `zoned_time_parse_complete(x)` did not throw the expected error.
  ── Failure ('test-zoned-time.R:239:3'): zone name must be valid ────────────────
  `zoned_time_parse_complete(x)` did not throw the expected error.
  ── Failure ('test-zoned-time.R:279:3'): `x` is translated to UTF-8 ─────────────
  zoned_time_parse_complete(x, format = format, locale = locale) (`actual`) not identical to as_zoned_time(...) (`expected`).
  
  `attr(actual, 'zone')`:   "UTC"             
  `attr(expected, 'zone')`: "America/New_York"
  
    `actual$lower`:           NA
  `expected$lower`: 2147483648.0
  
    `actual$upper`:           NA
  `expected$upper`: 1549000923.0
  ── Failure ('test-zoned-time.R:292:3'): leftover subseconds result in a parse failure ──
  zoned_time_parse_complete(x, precision = "microsecond") (`actual`) not identical to as_zoned_time(...) (`expected`).
  
  `attr(actual, 'zone')`:   "UTC"             
  `attr(expected, 'zone')`: "America/New_York"
  
    `actual$lower`:           NA
  `expected$lower`: 2147843679.0
  
    `actual$upper`:           NA
  `expected$upper`: 1090577624.0
  ── Failure ('test-zoned-time.R:318:3'): parsing rounds parsed subsecond components more precise than the resulting container (#207) (#230) (undocumented) ──
  zoned_time_parse_complete(x, precision = "millisecond", format = "%Y-%m-%d %H:%M:%7S%Ez[%Z]") (`actual`) not identical to as_zoned_time(...) (`expected`).
  
  `attr(actual, 'zone')`:   "UTC"             
  `attr(expected, 'zone')`: "America/New_York"
  
    `actual$lower`:           NA
  `expected$lower`: 2147484008.0
  
    `actual$upper`:          NA
  `expected$upper`: 134234564.0
  ── Failure ('test-zoned-time.R:355:3'): can parse with abbreviation and zone name ──
  zoned_time_parse_abbrev("2019-01-01 01:02:03 EST", "America/New_York") (`actual`) not identical to zoned_time_parse_complete("2019-01-01T01:02:03-05:00[America/New_York]") (`expected`).
  
  `attr(actual, 'zone')`:   "America/New_York"
  `attr(expected, 'zone')`: "UTC"             
  
    `actual$lower`: 2147483648.0
  `expected$lower`:           NA
  
    `actual$upper`: 1546322523.0
  `expected$upper`:           NA
  ── Failure ('test-zoned-time.R:362:3'): can parse when abbreviation is an offset ──
  zoned_time_parse_abbrev("2019-01-01 01:02:03 +11", "Australia/Lord_Howe") (`actual`) not identical to zoned_time_parse_complete("2019-01-01T01:02:03+11:00[Australia/Lord_Howe]") (`expected`).
  
  `attr(actual, 'zone')`:   "Australia/Lord_Howe"
  `attr(expected, 'zone')`: "UTC"                
  
    `actual$lower`: 2147483648.0
  `expected$lower`:           NA
  
    `actual$upper`: 1546264923.0
  `expected$upper`:           NA
  ── Failure ('test-zoned-time.R:366:3'): can parse when abbreviation is an offset ──
  zoned_time_parse_abbrev("2019-10-01 01:02:03 +1030", "Australia/Lord_Howe") (`actual`) not identical to zoned_time_parse_complete("2019-10-01T01:02:03+10:30[Australia/Lord_Howe]") (`expected`).
  
  `attr(actual, 'zone')`:   "Australia/Lord_Howe"
  `attr(expected, 'zone')`: "UTC"                
  
    `actual$lower`: 2147483648.0
  `expected$lower`:           NA
  
    `actual$upper`: 1569853923.0
  `expected$upper`:           NA
  ── Failure ('test-zoned-time.R:421:3'): abbreviation is used to resolve ambiguity ──
  zoned_time_parse_abbrev(x, "America/New_York") (`actual`) not identical to zoned_time_parse_complete(expect) (`expected`).
  
  `attr(actual, 'zone')`:   "America/New_York"
  `attr(expected, 'zone')`: "UTC"             
  
    `actual$lower`: 2147483648.0 2147483648.0
  `expected$lower`:           NA           NA
  
    `actual$upper`: 25680600.0 25684200.0
  `expected$upper`:         NA         NA
  ── Failure ('test-zoned-time.R:472:3'): %z can be parsed (but is ignored really) ──
  zoned_time_parse_abbrev(x, "America/New_York", format = "%Y-%m-%d %H:%M:%S%Ez %Z") (`actual`) not identical to `expect` (`expected`).
  
  `attr(actual, 'zone')`:   "America/New_York"
  `attr(expected, 'zone')`: "UTC"             
  ── Failure ('test-zoned-time.R:482:3'): %z that is incorrect technically slips through unnoticed ──
  zoned_time_parse_abbrev(x, "America/New_York", format = "%Y-%m-%d %H:%M:%S%Ez %Z") (`actual`) not identical to `expect` (`expected`).
  
  `attr(actual, 'zone')`:   "America/New_York"
  `attr(expected, 'zone')`: "UTC"             
  ── Failure ('test-zoned-time.R:543:3'): `x` is translated to UTF-8 ─────────────
  zoned_time_parse_abbrev(...) (`actual`) not identical to as_zoned_time(...) (`expected`).
  
    `actual$lower`:           NA
  `expected$lower`: 2147483648.0
  
    `actual$upper`:           NA
  `expected$upper`: 1549000923.0
  
  [ FAIL 33 | WARN 29 | SKIP 360 | PASS 1860 ]
  Error: Test failures
  Execution halted
* checking package vignettes ... OK
* checking re-building of vignette outputs ... [39s/49s] OK
* DONE
Status: 1 ERROR, 1 WARNING
```